### PR TITLE
Add responsive layouts and metrics dashboard

### DIFF
--- a/app/routes/clients.py
+++ b/app/routes/clients.py
@@ -40,7 +40,8 @@ def update_client():
     data = request.get_json()
     old_name = data.get("old_name")
     new_name = data.get("new_name")
-    new_manager = data.get("new_manager")
+    # поддерживаем старый ключ manager на случай старого JS
+    new_manager = data.get("new_manager") or data.get("manager") or ""
 
     updated = False
     with clients_lock:

--- a/app/routes/orders.py
+++ b/app/routes/orders.py
@@ -110,6 +110,14 @@ def index():
     return render_template("index.html")
 
 
+@orders_bp.route("/metrics")
+def metrics_page():
+    if not getattr(g, "role_perms", {}).get("can_access_metrics"):
+        return redirect(url_for("orders.index"))
+
+    return render_template("metrics.html")
+
+
 @orders_bp.route("/facades")
 def facades_page():
     if not getattr(g, "role_perms", {}).get("can_access_facades"):

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -1045,6 +1045,147 @@ const SearchPage = (() => {
   return { init };
 })();
 
+const MetricsPage = (() => {
+  let rpsCtx;
+  let sseCtx;
+  let errorCtx;
+  let timer = null;
+  const sseHistory = [];
+  const errorHistory = [];
+  const pollMs = 5000;
+
+  function init() {
+    const container = document.querySelector('[data-metrics-page]');
+    if (!container) return;
+
+    rpsCtx = container.querySelector('#rpsChart')?.getContext('2d') || null;
+    sseCtx = container.querySelector('#sseChart')?.getContext('2d') || null;
+    errorCtx = container.querySelector('#errorChart')?.getContext('2d') || null;
+
+    fetchAndRender();
+    timer = setInterval(fetchAndRender, pollMs);
+    document.addEventListener('visibilitychange', () => {
+      if (!document.hidden) fetchAndRender();
+    });
+  }
+
+  async function fetchAndRender() {
+    try {
+      const response = await fetch('/api/metrics', { headers: { 'X-Requested-With': 'XMLHttpRequest' } });
+      if (!response.ok) throw new Error('Ответ сервера с ошибкой');
+      const data = await response.json();
+      updateSummary(data);
+      drawRpsChart(data?.requests?.last_minute_rps || []);
+      pushHistory(sseHistory, data?.sse?.active_clients ?? 0, 60);
+      pushHistory(errorHistory, data?.errors?.errors_last_24h ?? 0, 60);
+      drawSparkline(sseCtx, sseHistory, '#2563eb');
+      drawSparkline(errorCtx, errorHistory, '#dc2626');
+      setMeta('Обновлено: ' + new Date().toLocaleTimeString());
+      setText('[data-sse-meta]', `${(data?.sse?.seconds_ago ?? 0) || 0} c назад`);
+      setText('[data-errors-meta]', `${data?.errors?.errors_last_24h ?? 0} за сутки`);
+    } catch (error) {
+      console.error('Metrics fetch failed', error);
+      setMeta('Нет данных');
+    }
+  }
+
+  function updateSummary(data) {
+    const nowSec = Date.now() / 1000;
+    const started = data?.started_at || nowSec;
+    const uptime = Math.max(0, Math.round(nowSec - started));
+    const rpsValues = data?.requests?.last_minute_rps || [];
+    const currentRps = rpsValues.length ? rpsValues[rpsValues.length - 1] : 0;
+
+    setText('[data-rps-current]', currentRps?.toFixed ? currentRps.toFixed(2) : currentRps || 0);
+    setText('[data-sse-count]', data?.sse?.active_clients ?? '—');
+    setText('[data-errors-day]', data?.errors?.errors_last_24h ?? '—');
+    setText('[data-uptime]', formatUptime(uptime));
+  }
+
+  function drawRpsChart(values) {
+    if (!rpsCtx) return;
+    const ctx = rpsCtx;
+    const width = ctx.canvas.width;
+    const height = ctx.canvas.height;
+    ctx.clearRect(0, 0, width, height);
+    if (!values.length) return;
+
+    const maxVal = Math.max(...values, 1);
+    const stepX = values.length > 1 ? width / (values.length - 1) : width;
+    ctx.lineWidth = 2;
+    ctx.strokeStyle = '#2563eb';
+    ctx.fillStyle = 'rgba(37, 99, 235, 0.12)';
+    ctx.beginPath();
+
+    values.forEach((val, idx) => {
+      const x = idx * stepX;
+      const y = height - (val / maxVal) * (height - 10);
+      if (idx === 0) {
+        ctx.moveTo(x, y);
+      } else {
+        ctx.lineTo(x, y);
+      }
+    });
+
+    ctx.stroke();
+    ctx.lineTo(width, height);
+    ctx.lineTo(0, height);
+    ctx.closePath();
+    ctx.fill();
+  }
+
+  function drawSparkline(ctx, values, color = '#2563eb') {
+    if (!ctx) return;
+    const width = ctx.canvas.width;
+    const height = ctx.canvas.height;
+    ctx.clearRect(0, 0, width, height);
+    if (!values.length) return;
+
+    const maxVal = Math.max(...values, 1);
+    const stepX = values.length > 1 ? width / (values.length - 1) : width;
+    ctx.strokeStyle = color;
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+
+    values.forEach((val, idx) => {
+      const x = idx * stepX;
+      const y = height - (val / maxVal) * (height - 6);
+      if (idx === 0) {
+        ctx.moveTo(x, y);
+      } else {
+        ctx.lineTo(x, y);
+      }
+    });
+
+    ctx.stroke();
+  }
+
+  function pushHistory(store, value, limit) {
+    store.push(Number(value) || 0);
+    if (store.length > limit) store.shift();
+  }
+
+  function setMeta(text) {
+    setText('[data-metrics-status]', text);
+  }
+
+  function setText(selector, value) {
+    const el = document.querySelector(selector);
+    if (el) {
+      el.textContent = value;
+    }
+  }
+
+  function formatUptime(seconds) {
+    if (seconds === null || seconds === undefined) return '—';
+    const hrs = Math.floor(seconds / 3600);
+    const mins = Math.floor((seconds % 3600) / 60);
+    return `${hrs} ч ${mins} м`;
+  }
+
+  return { init };
+})();
+
 const FacadesPage = (() => {
   function init() {
     const container = document.getElementById('facadeList');
@@ -1258,6 +1399,7 @@ document.addEventListener('DOMContentLoaded', () => {
   OrdersPage.init();
   ClientsPage.init();
   SearchPage.init();
+  MetricsPage.init();
   FacadesPage.init();
   SettingsPage.init();
   UsersTable.init();
@@ -1311,14 +1453,17 @@ const ClientsTable = (() => {
       body: JSON.stringify({
         old_name: oldName,
         new_name: newName,
-        manager: newManager
+        new_manager: newManager
       })
     })
       .then(r => r.json())
       .then(res => {
         if (res.status === 'ok') {
           row.dataset.client = newName;
-          row.querySelector('[data-view]').textContent = newName;
+          const nameCell = row.querySelector('[data-field="name"]');
+          const managerCell = row.querySelector('[data-field="manager"]');
+          if (nameCell) nameCell.textContent = newName;
+          if (managerCell) managerCell.textContent = newManager || '—';
           location.reload();
         } else {
           alert(res.message || 'Ошибка сохранения');

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -256,6 +256,11 @@ h1 {
   color: var(--text-muted);
 }
 
+.field-label--compact {
+  font-size: 0.8rem;
+  letter-spacing: 0.03em;
+}
+
 .input,
 .select,
 textarea,
@@ -303,6 +308,12 @@ select:focus {
   padding: 8px 10px;
   min-width: 180px;
   height: auto;
+}
+
+.select--pill {
+  border-radius: 999px;
+  min-width: 150px;
+  padding: 6px 12px;
 }
 
 .settings-form {
@@ -449,6 +460,8 @@ select:focus {
 
 .table-scroll {
   overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: thin;
 }
 
 .data-table {
@@ -456,6 +469,10 @@ select:focus {
   border-collapse: separate;
   border-spacing: 0;
   min-width: 720px;
+}
+
+.data-table--stacked {
+  min-width: 0;
 }
 
 .data-table thead {
@@ -1142,7 +1159,11 @@ code {
   grid-template-columns: 18px 1fr;
   align-items: flex-start;
   gap: 10px;
-  padding: 8px 0;
+  padding: 10px 12px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 10px;
+  background: rgba(248, 250, 252, 0.8);
+  transition: border-color 0.2s ease, transform 0.15s ease;
 }
 
 .checkbox-row input[type="checkbox"] {
@@ -1163,6 +1184,11 @@ code {
 .checkbox-row__desc {
   color: var(--text-muted);
   font-size: 0.92rem;
+}
+
+.checkbox-row:hover {
+  border-color: rgba(37, 99, 235, 0.4);
+  transform: translateY(-1px);
 }
 
 .role-grid {
@@ -1269,4 +1295,182 @@ code {
 .btn--ghost.btn--disabled {
   opacity: 0.5;
   pointer-events: none;
+}
+.metrics-shell {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.metrics-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+}
+
+.metric-chip {
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.08), rgba(16, 185, 129, 0.08));
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.metric-chip__label {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  letter-spacing: 0.03em;
+}
+
+.metric-chip__value {
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: var(--primary);
+}
+
+.charts-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 14px;
+}
+
+.chart-card {
+  padding: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 16px;
+  background: #fff;
+  box-shadow: 0 12px 28px -24px rgba(15, 23, 42, 0.35);
+}
+
+.chart-card--wide {
+  grid-column: 1 / -1;
+}
+
+.chart-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.chart-card__title {
+  margin: 0;
+}
+
+.chart-card__hint {
+  margin: 4px 0 0;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.chart-card__meta {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.chart-card canvas {
+  width: 100%;
+}
+
+@media (max-width: 1024px) {
+  .page {
+    padding: 24px 18px 48px;
+  }
+
+  .data-table th,
+  .data-table td {
+    padding: 12px 14px;
+  }
+}
+
+@media (max-width: 860px) {
+  .top-menu {
+    gap: 8px;
+  }
+
+  .top-menu a,
+  .top-menu .btn {
+    padding: 8px 12px;
+  }
+
+  .controls-grid {
+    gap: 12px;
+  }
+
+  .controls-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .data-table--stacked,
+  .data-table--stacked thead,
+  .data-table--stacked tbody,
+  .data-table--stacked th,
+  .data-table--stacked tr,
+  .data-table--stacked td {
+    display: block;
+    width: 100%;
+  }
+
+  .data-table--stacked thead {
+    position: absolute;
+    left: -9999px;
+  }
+
+  .data-table--stacked tbody tr {
+    margin-bottom: 12px;
+    padding: 10px 12px;
+    border: 1px solid rgba(148, 163, 184, 0.22);
+    border-radius: 12px;
+    background: rgba(248, 250, 252, 0.9);
+  }
+
+  .data-table--stacked td {
+    border: 0;
+    padding: 8px 4px;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.15);
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+    align-items: flex-start;
+  }
+
+  .data-table--stacked td:last-child {
+    border-bottom: 0;
+  }
+
+  .data-table--stacked td::before {
+    content: attr(data-label);
+    font-weight: 700;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    font-size: 0.78rem;
+  }
+}
+
+@media (max-width: 640px) {
+  .page {
+    padding: 18px 14px 36px;
+  }
+
+  .page-header h1 {
+    font-size: 1.6rem;
+  }
+
+  .form-inline {
+    gap: 10px;
+  }
+
+  .table-scroll {
+    margin: 0 -6px;
+    padding: 0 6px;
+  }
+
+  .metric-chip__value {
+    font-size: 1.2rem;
+  }
 }

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -31,6 +31,9 @@
       {% if role_perms.can_access_search %}
       <a href="/search">🔍 Поиск</a>
       {% endif %}
+      {% if role_perms.can_access_metrics %}
+      <a href="/metrics">📈 Метрики</a>
+      {% endif %}
       {% if role_perms.can_access_facades %}
       <a href="/facades">🚪 Фасады</a>
       {% endif %}

--- a/app/templates/clients.html
+++ b/app/templates/clients.html
@@ -32,7 +32,7 @@ data-managers="{{ config_managers | join(',') }}"
 
   <section class="card table-card clients-table">
     <div class="table-scroll">
-      <table class="data-table" data-clients-table>
+      <table class="data-table data-table--stacked" data-clients-table>
         <thead>
           <tr>
             <th>Клиент</th>
@@ -43,19 +43,19 @@ data-managers="{{ config_managers | join(',') }}"
         <tbody>
           {% for client, manager in clients.items() %}
           <tr data-client="{{ client }}">
-            <td>
-              <span class="table-primary" data-view>{{ client }}</span>
+            <td data-label="Клиент">
+              <span class="table-primary" data-view data-field="name">{{ client }}</span>
               <input type="text" class="input edit-name is-hidden" data-edit value="{{ client }}">
             </td>
-            <td>
-              <span class="manager-tag" data-view>{{ manager }}</span>
+            <td data-label="Менеджер">
+              <span class="manager-tag" data-view data-field="manager">{{ manager }}</span>
               <select class="select edit-manager is-hidden" data-edit>
                 {% for manager_name in config_managers %}
                 <option value="{{ manager_name }}" {% if manager_name == manager %}selected{% endif %}>{{ manager_name }}</option>
                 {% endfor %}
               </select>
             </td>
-            <td>
+            <td data-label="Действия">
               <div class="button-group button-group--inline" data-view>
                 <button type="button" class="btn btn--ghost btn--small" data-edit-btn>✏️ Изменить</button>
                 <button type="button" class="btn btn--ghost btn--small" data-delete-btn>🗑️ Удалить</button>

--- a/app/templates/journal.html
+++ b/app/templates/journal.html
@@ -12,7 +12,7 @@
 
   <section class="card table-card">
     <div class="table-scroll">
-      <table class="data-table">
+      <table class="data-table data-table--stacked">
         <thead>
           <tr>
             <th>Время</th>
@@ -24,10 +24,10 @@
         <tbody>
           {% for event in events %}
           <tr>
-            <td class="table-secondary">{{ event.ts.strftime('%d.%m.%Y %H:%M') if event.ts else '—' }}</td>
-            <td>{{ event.user or 'system' }}</td>
-            <td>{{ event.action }}</td>
-            <td>
+            <td class="table-secondary" data-label="Время">{{ event.ts.strftime('%d.%m.%Y %H:%M') if event.ts else '—' }}</td>
+            <td data-label="Пользователь">{{ event.user or 'system' }}</td>
+            <td data-label="Событие">{{ event.action }}</td>
+            <td data-label="Описание">
               {% if event.action in ['create', 'delete', 'rename', 'confirm'] %}
                 Заказ: <strong>{{ event.order_name or '—' }}</strong>
                 {% if event.action == 'create' %}- создан{% endif %}

--- a/app/templates/metrics.html
+++ b/app/templates/metrics.html
@@ -1,0 +1,72 @@
+{% extends "base.html" %}
+
+{% block title %}Метрики сервера{% endblock %}
+
+{% block body_attrs %}
+data-page="metrics"
+{% endblock %}
+
+{% block content %}
+  <header class="page-header">
+    <h1>📈 Метрики и состояние</h1>
+    <p class="page-description">
+      Текущая загрузка сервиса, активные SSE-подключения и ошибки за последние 24 часа. Данные обновляются автоматически.
+    </p>
+  </header>
+
+  <section class="card metrics-shell" data-metrics-page>
+    <div class="metrics-summary">
+      <div class="metric-chip">
+        <span class="metric-chip__label">RPS (текущ.)</span>
+        <strong class="metric-chip__value" data-rps-current>—</strong>
+      </div>
+      <div class="metric-chip">
+        <span class="metric-chip__label">Активные SSE</span>
+        <strong class="metric-chip__value" data-sse-count>—</strong>
+      </div>
+      <div class="metric-chip">
+        <span class="metric-chip__label">Ошибок за 24ч</span>
+        <strong class="metric-chip__value" data-errors-day>—</strong>
+      </div>
+      <div class="metric-chip">
+        <span class="metric-chip__label">Uptime</span>
+        <strong class="metric-chip__value" data-uptime>—</strong>
+      </div>
+    </div>
+
+    <div class="metrics-grid charts-grid">
+      <article class="chart-card chart-card--wide">
+        <header class="chart-card__header">
+          <div>
+            <h3 class="chart-card__title">RPS, последние 60 секунд</h3>
+            <p class="chart-card__hint">История запросов обновляется каждые несколько секунд.</p>
+          </div>
+          <span class="chart-card__meta" data-metrics-status>—</span>
+        </header>
+        <canvas id="rpsChart" height="200"></canvas>
+      </article>
+
+      <article class="chart-card">
+        <header class="chart-card__header">
+          <div>
+            <h3 class="chart-card__title">Активные SSE</h3>
+            <p class="chart-card__hint">Подписки браузеров на потоковые события.</p>
+          </div>
+          <span class="chart-card__meta" data-sse-meta>—</span>
+        </header>
+        <canvas id="sseChart" height="140"></canvas>
+      </article>
+
+      <article class="chart-card">
+        <header class="chart-card__header">
+          <div>
+            <h3 class="chart-card__title">Ошибки за 24 часа</h3>
+            <p class="chart-card__hint">Счётчик критичных событий.</p>
+          </div>
+          <span class="chart-card__meta" data-errors-meta>—</span>
+        </header>
+        <canvas id="errorChart" height="140"></canvas>
+      </article>
+    </div>
+  </section>
+{% endblock %}

--- a/app/templates/search.html
+++ b/app/templates/search.html
@@ -20,8 +20,8 @@ data-managers="{{ config_managers | join(',') }}"
     <h2 class="section-title">Поисковый запрос</h2>
     <form method="POST" action="{{ url_for('orders.search_page') }}" class="form-inline search-form">
       <input type="text" name="query" class="input" placeholder="Введите номер заказа (например 123-10)" value="{{ query }}" required>
-      <label class="field-label" for="period">Период</label>
-      <select name="period" id="period" class="select select--compact">
+      <label class="field-label field-label--compact" for="period">Период</label>
+      <select name="period" id="period" class="select select--compact select--pill">
         <option value="2" {% if period_choice == '2' %}selected{% endif %}>Последние 2 месяца</option>
         <option value="6" {% if period_choice == '6' %}selected{% endif %}>Последние 6 месяцев</option>
         <option value="12" {% if period_choice == '12' %}selected{% endif %}>Последние 12 месяцев</option>

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -158,7 +158,7 @@ data-managers="{{ config_managers | join(',') }}"
       <div class="password-notice__text" data-password-text></div>
     </div>
 
-    <div class="users-table-wrapper">
+    <div class="users-table-wrapper table-scroll">
       <table class="data-table users-table" data-users-table>
         <thead>
           <tr>


### PR DESCRIPTION
## Summary
- add responsive table styles and UI polish across orders, clients, journal, search, and settings pages
- fix client manager updates to keep assignments visible after edits
- introduce a metrics dashboard page with live charts fed by the existing /api/metrics endpoint

## Testing
- python -m compileall app

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936277a37f4832d89acf79e3aefbe50)