### PR TITLE
Polish settings and client UI layout

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -161,11 +161,13 @@ def inject_config_data():
 
 
 def register_blueprints(flask_app: Flask):
+    from app.routes.setup import setup_bp
     from app.routes.auth import auth_bp
     from app.routes.clients import clients_bp
     from app.routes.orders import orders_bp
     from app.routes.settings import settings_bp
 
+    flask_app.register_blueprint(setup_bp)
     flask_app.register_blueprint(auth_bp)
     flask_app.register_blueprint(orders_bp)
     flask_app.register_blueprint(clients_bp)

--- a/app/config.py
+++ b/app/config.py
@@ -21,6 +21,10 @@ DEFAULT_CONFIG = {
     "paths": {
         "orders": "",
         "facades_dir": "",
+        "prisadka_root": "",
+        "desene_cpu_root": "",
+        "prisadka_client_root": "",
+        "facades_list_dir": "",
         "search": {},
     },
     "managers": [],
@@ -41,6 +45,10 @@ FACADES_DIR = ""
 FACADES_FILE = ""
 WATCHED_PATH = ""
 WATCHED_PATH_NORM = ""
+PRISADKA_ROOT = ""
+DESENE_CPU_ROOT = ""
+PRISADKA_CLIENT_ROOT = ""
+FACADES_LIST_DIR = ""
 TELEGRAM_TOKEN = ""
 CHAT_ID = ""
 TELEGRAM_IGNORED_FOLDERS: list[str] = []
@@ -161,11 +169,19 @@ def _parse_paths_config(value: dict) -> dict:
 
     orders_path = str(value.get("orders") or "").strip()
     facades_dir = str(value.get("facades_dir") or "").strip()
+    prisadka_root = str(value.get("prisadka_root") or "").strip()
+    desene_cpu_root = str(value.get("desene_cpu_root") or "").strip()
+    prisadka_client_root = str(value.get("prisadka_client_root") or "").strip()
+    facades_list_dir = str(value.get("facades_list_dir") or "").strip()
     search_folders = _parse_search_folders(value.get("search"))
 
     return {
         "orders": orders_path,
         "facades_dir": facades_dir,
+        "prisadka_root": prisadka_root,
+        "desene_cpu_root": desene_cpu_root,
+        "prisadka_client_root": prisadka_client_root,
+        "facades_list_dir": facades_list_dir,
         "search": search_folders,
     }
 
@@ -231,6 +247,7 @@ def apply_config(config):
 
     global CONFIG
     global FOLDER_PATH, FACADES_DIR, FACADES_FILE, WATCHED_PATH, WATCHED_PATH_NORM
+    global PRISADKA_ROOT, DESENE_CPU_ROOT, PRISADKA_CLIENT_ROOT, FACADES_LIST_DIR
     global TELEGRAM_TOKEN, CHAT_ID, SERVER_HOST, SERVER_PORT, DEBUG_MODE
     global SEARCH_FOLDERS, MANAGER_NAMES, TECHNOLOGIST_MARKERS, SEARCH_MONTHS
     global ORDER_CONFIRMATION_ENABLED, CONFIG_WARNINGS
@@ -255,6 +272,10 @@ def apply_config(config):
 
     FOLDER_PATH = paths.get("orders") or ""
     FACADES_DIR = paths.get("facades_dir") or ""
+    PRISADKA_ROOT = paths.get("prisadka_root") or ""
+    DESENE_CPU_ROOT = paths.get("desene_cpu_root") or ""
+    PRISADKA_CLIENT_ROOT = paths.get("prisadka_client_root") or ""
+    FACADES_LIST_DIR = paths.get("facades_list_dir") or FACADES_DIR
     FACADES_FILE = (
         os.path.join(FACADES_DIR, "facades_list.txt") if FACADES_DIR else "facades_list.txt"
     )
@@ -283,6 +304,16 @@ def apply_config(config):
         warning = f"Папка для facades_list.txt '{FACADES_DIR}' не найдена"
         warnings.append(warning)
         logger.warning("[config] %s", warning)
+    for label, path in [
+        ("Путь присадки", PRISADKA_ROOT),
+        ("DESENE CPU", DESENE_CPU_ROOT),
+        ("Присадка клиента", PRISADKA_CLIENT_ROOT),
+        ("Папка facades_list", FACADES_LIST_DIR),
+    ]:
+        if path and not os.path.exists(path):
+            warning = f"{label} '{path}' не найден"
+            warnings.append(warning)
+            logger.warning("[config] %s", warning)
     for name, folder in SEARCH_FOLDERS.items():
         if folder and not os.path.exists(folder):
             warning = f"Путь поиска '{name}' -> '{folder}' недоступен"
@@ -316,6 +347,7 @@ __all__ = [
     "WATCHED_PATH_NORM",
     "FACADES_DIR",
     "FACADES_FILE",
+    "FACADES_LIST_DIR",
     "CHAT_ID",
     "TELEGRAM_TOKEN",
     "TELEGRAM_IGNORED_FOLDERS",
@@ -324,6 +356,9 @@ __all__ = [
     "DEBUG_MODE",
     "SEARCH_FOLDERS",
     "SEARCH_MONTHS",
+    "PRISADKA_ROOT",
+    "DESENE_CPU_ROOT",
+    "PRISADKA_CLIENT_ROOT",
     "ORDER_CONFIRMATION_ENABLED",
     "apply_config",
     "save_config",

--- a/app/dal/database.py
+++ b/app/dal/database.py
@@ -1,7 +1,7 @@
 import json
-from typing import Dict, Iterable, List
+from typing import Dict, Iterable, List, Tuple
 
-from sqlalchemy import Column, Integer, String, Text
+from sqlalchemy import Column, Integer, String, Text, func
 
 from app.dal.db import Base, SessionLocal
 
@@ -26,6 +26,33 @@ def get_all_clients() -> Dict[str, str]:
     with SessionLocal.begin() as session:
         rows = session.query(Client).order_by(Client.name.asc()).all()
         return {row.name: row.manager or "" for row in rows}
+
+
+def get_clients_filtered(query: str | None) -> Dict[str, str]:
+    """Возвращает клиентов, отфильтрованных по подстроке имени."""
+    normalized = (query or "").strip().lower()
+    with SessionLocal.begin() as session:
+        q = session.query(Client)
+        if normalized:
+            like_pattern = f"%{normalized}%"
+            q = q.filter(func.lower(Client.name).like(like_pattern))
+        rows = q.order_by(Client.name.asc()).all()
+        return {row.name: row.manager or "" for row in rows}
+
+
+def get_clients_stats_by_manager() -> List[Tuple[str, int]]:
+    """Компактная статистика: сколько клиентов у каждого менеджера."""
+    with SessionLocal.begin() as session:
+        rows = (
+            session.query(Client.manager, func.count().label("count"))
+            .group_by(Client.manager)
+            .order_by(Client.manager.asc())
+            .all()
+        )
+        prepared: List[Tuple[str, int]] = []
+        for manager, count in rows:
+            prepared.append((manager or "Неизвестно", int(count)))
+        return prepared
 
 
 def replace_clients(clients: Dict[str, str]) -> None:
@@ -90,6 +117,8 @@ __all__ = [
     "add_client",
     "delete_client",
     "get_all_clients",
+    "get_clients_filtered",
+    "get_clients_stats_by_manager",
     "load_messages",
     "replace_clients",
     "replace_messages",

--- a/app/dal/users.py
+++ b/app/dal/users.py
@@ -30,6 +30,16 @@ def _count_admins(session) -> int:
     ).scalar_one()
 
 
+def count_users() -> int:
+    with SessionLocal.begin() as session:
+        return session.execute(select(func.count()).select_from(User)).scalar_one()
+
+
+def count_active_admins() -> int:
+    with SessionLocal.begin() as session:
+        return _count_admins(session)
+
+
 def _error(code: str, message: str) -> Dict[str, str]:
     return {"ok": False, "error_code": code, "message": message}
 
@@ -89,6 +99,34 @@ def create_user(username: str, password: str, role: str) -> Dict[str, str]:
         return {"ok": True}
     except IntegrityError:
         return _error("username_taken", "Пользователь с таким именем уже существует.")
+
+
+def upsert_user(username: str, password: str, role: str) -> Dict[str, str]:
+    username = (username or "").strip()
+    role = (role or "").strip().lower()
+
+    if not username or not password:
+        return _error("validation", "Имя пользователя и пароль обязательны.")
+
+    if role not in _allowed_roles():
+        return _error("invalid_role", "Недопустимая роль.")
+
+    password_hash = generate_password_hash(password)
+
+    try:
+        with SessionLocal.begin() as session:
+            user = session.execute(select(User).where(User.username == username)).scalar_one_or_none()
+            if user:
+                user.password_hash = password_hash
+                user.role = role
+                user.is_active = True
+            else:
+                session.add(User(username=username, password_hash=password_hash, role=role, is_active=True))
+        return {"ok": True, "username": username, "role": role}
+    except IntegrityError:
+        return _error("username_taken", "Пользователь с таким именем уже существует.")
+    except Exception:
+        return _error("db_error", "Не удалось сохранить пользователя.")
 
 
 def update_user_role(user_id: int, role: str) -> Dict[str, str]:
@@ -230,6 +268,9 @@ __all__ = [
     "get_allowed_roles",
     "get_all_users",
     "get_user_by_username",
+    "count_users",
+    "count_active_admins",
+    "upsert_user",
     "reset_user_password_random",
     "reset_user_password",
     "update_user",

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -20,7 +20,7 @@ from app.dal.users import verify_user_credentials
 auth_bp = Blueprint("auth", __name__)
 logger = logging.getLogger("bazis")
 
-PUBLIC_ENDPOINTS = {"auth.login", "static", "orders.ping"}
+PUBLIC_ENDPOINTS = {"auth.login", "static", "orders.ping", "setup.setup_page"}
 
 
 def login_required(view: Callable):

--- a/app/routes/clients.py
+++ b/app/routes/clients.py
@@ -3,6 +3,7 @@ from flask import Blueprint, g, jsonify, redirect, render_template, request, url
 from app import clients, clients_lock, reload_clients_from_db
 from app.dal.database import add_client as add_client_db
 from app.dal.database import delete_client as delete_client_db
+from app.dal.database import get_clients_filtered, get_clients_stats_by_manager
 from app.dal.database import update_client as update_client_db
 from app.dal.permissions import permissions_required
 
@@ -14,9 +15,16 @@ def clients_page():
     if not getattr(g, "role_perms", {}).get("can_access_clients"):
         return redirect(url_for("orders.index"))
 
-    with clients_lock:
-        clients_snapshot = dict(clients)
-    return render_template("clients.html", clients=clients_snapshot)
+    search_query = (request.args.get("q") or "").strip()
+    clients_snapshot = get_clients_filtered(search_query)
+    manager_stats = get_clients_stats_by_manager()
+
+    return render_template(
+        "clients.html",
+        clients=clients_snapshot,
+        search_query=search_query,
+        manager_stats=manager_stats,
+    )
 
 
 @clients_bp.route("/add_client", methods=["POST"])

--- a/app/routes/orders.py
+++ b/app/routes/orders.py
@@ -33,6 +33,7 @@ from app.services.audit import log_order_event
 from app.services.monitor import move_known_folder
 from app.services.snapshot import (
     build_orders_payload,
+    calculate_period_cutoff,
     refresh_search_index,
     remove_order,
     collect_month_scope,
@@ -149,6 +150,8 @@ def search_page():
         except (TypeError, ValueError):
             months_back = 2
 
+    period_cutoff_ts = calculate_period_cutoff(months_back) if months_back else None
+
     results = {key: [] for key in app_config.SEARCH_FOLDERS.keys()}
 
     if query:
@@ -164,7 +167,7 @@ def search_page():
         else:
             month_scope = collect_month_scope(months_back)
 
-        results = search_in_index(query, months_scope=month_scope)
+        results = search_in_index(query, months_scope=month_scope, cutoff_ts=period_cutoff_ts)
     else:
         month_scope = collect_month_scope(months_back)
 

--- a/app/routes/settings.py
+++ b/app/routes/settings.py
@@ -107,6 +107,10 @@ def settings_page():
         if role_perms.get("can_edit_paths"):
             orders_path = request.form.get("orders_path", "").strip()
             facades_dir = request.form.get("facades_dir", "").strip()
+            prisadka_root = request.form.get("prisadka_root", "").strip()
+            desene_cpu_root = request.form.get("desene_cpu_root", "").strip()
+            prisadka_client_root = request.form.get("prisadka_client_root", "").strip()
+            facades_list_dir = request.form.get("facades_list_dir", "").strip()
             search_raw = request.form.get("search_folders", "")
 
             server_host = request.form.get("server_host", "").strip()
@@ -121,6 +125,14 @@ def settings_page():
                 paths_cfg["orders"] = orders_path
             if facades_dir:
                 paths_cfg["facades_dir"] = facades_dir
+            if prisadka_root:
+                paths_cfg["prisadka_root"] = prisadka_root
+            if desene_cpu_root:
+                paths_cfg["desene_cpu_root"] = desene_cpu_root
+            if prisadka_client_root:
+                paths_cfg["prisadka_client_root"] = prisadka_client_root
+            if facades_list_dir:
+                paths_cfg["facades_list_dir"] = facades_list_dir
             paths_cfg["search"] = parse_mapping(search_raw)
 
             server_config = updated.setdefault("server", {})

--- a/app/routes/setup.py
+++ b/app/routes/setup.py
@@ -1,0 +1,196 @@
+from copy import deepcopy
+import logging
+
+from flask import Blueprint, flash, redirect, render_template, request, url_for
+
+from app.config import CONFIG, DEFAULT_CONFIG, apply_config, save_config
+from app.dal.users import upsert_user
+from app.services.setup_state import is_first_run
+
+logger = logging.getLogger("bazis")
+
+setup_bp = Blueprint("setup", __name__)
+
+
+@setup_bp.before_app_request
+def enforce_setup_wizard():
+    endpoint = request.endpoint or ""
+
+    if is_first_run():
+        if endpoint.startswith("setup.") or endpoint.startswith("static"):
+            return
+        return redirect(url_for("setup.setup_page"))
+
+    if endpoint.startswith("setup.") and endpoint != "static":
+        return redirect(url_for("auth.login"))
+
+
+def _parse_mapping(value: str) -> dict:
+    mapping = {}
+    for line in value.splitlines():
+        if "=" not in line:
+            continue
+        key, val = line.split("=", 1)
+        key = key.strip()
+        val = val.strip()
+        if key and val:
+            mapping[key] = val
+    return mapping
+
+
+def _collect_accounts(prefix: str) -> list[dict]:
+    names = request.form.getlist(f"{prefix}_name[]")
+    logins = request.form.getlist(f"{prefix}_username[]")
+    passwords = request.form.getlist(f"{prefix}_password[]")
+    markers = request.form.getlist(f"{prefix}_marker[]") if prefix == "technologist" else []
+
+    collected: list[dict] = []
+    for idx, (name, login, password) in enumerate(zip(names, logins, passwords)):
+        normalized_name = (name or "").strip()
+        normalized_login = (login or "").strip()
+        normalized_password = (password or "").strip()
+        marker = (markers[idx] if idx < len(markers) else "").strip() if markers else ""
+
+        if not any([normalized_name, normalized_login, normalized_password, marker]):
+            continue
+
+        collected.append(
+            {
+                "name": normalized_name,
+                "username": normalized_login,
+                "password": normalized_password,
+                "marker": marker,
+            }
+        )
+
+    return collected
+
+
+@setup_bp.route("/setup", methods=["GET", "POST"])
+def setup_page():
+    if not is_first_run():
+        return redirect(url_for("auth.login"))
+
+    errors: list[str] = []
+    status_message = None
+
+    config_snapshot = deepcopy(CONFIG if isinstance(CONFIG, dict) else DEFAULT_CONFIG)
+    managers_form = _collect_accounts("manager") if request.method == "POST" else []
+    technologists_form = _collect_accounts("technologist") if request.method == "POST" else []
+
+    if request.method == "POST":
+        orders_path = request.form.get("orders_path", "").strip()
+        facades_dir = request.form.get("facades_dir", "").strip()
+        prisadka_root = request.form.get("prisadka_root", "").strip()
+        desene_cpu_root = request.form.get("desene_cpu_root", "").strip()
+        prisadka_client_root = request.form.get("prisadka_client_root", "").strip()
+        facades_list_dir = request.form.get("facades_list_dir", "").strip()
+        search_raw = request.form.get("search_folders", "")
+
+        telegram_token = request.form.get("telegram_token", "").strip()
+        telegram_chat = request.form.get("telegram_chat_id", "").strip()
+
+        admin_username = (request.form.get("admin_username") or "").strip()
+        admin_password = (request.form.get("admin_password") or "").strip()
+        admin_display = (request.form.get("admin_display") or "").strip()
+
+        paths_snapshot = config_snapshot.setdefault("paths", {})
+        paths_snapshot["orders"] = orders_path
+        paths_snapshot["facades_dir"] = facades_dir
+        paths_snapshot["prisadka_root"] = prisadka_root
+        paths_snapshot["desene_cpu_root"] = desene_cpu_root
+        paths_snapshot["prisadka_client_root"] = prisadka_client_root
+        paths_snapshot["facades_list_dir"] = facades_list_dir
+        paths_snapshot["search"] = _parse_mapping(search_raw)
+
+        telegram_snapshot = config_snapshot.setdefault("telegram", {})
+        telegram_snapshot["token"] = telegram_token
+        telegram_snapshot["chat_id"] = telegram_chat
+
+        if not admin_username or not admin_password:
+            errors.append("Укажите логин и пароль администратора.")
+
+        managers = managers_form or _collect_accounts("manager")
+        technologists = technologists_form or _collect_accounts("technologist")
+
+        missing_credentials = [item for item in managers + technologists if not item.get("username") or not item.get("password")]
+        if missing_credentials:
+            errors.append("Каждый менеджер и технолог должен содержать логин и пароль.")
+
+        manager_names = [item.get("name") or item.get("username") for item in managers if item.get("username")]
+        tech_markers = {
+            (item.get("marker") or item.get("username") or item.get("name")): (item.get("name") or item.get("username"))
+            for item in technologists
+            if item.get("username")
+        }
+
+        if not manager_names:
+            fallback_manager = admin_display or admin_username
+            if fallback_manager:
+                manager_names.append(fallback_manager)
+            else:
+                errors.append("Добавьте хотя бы одного менеджера или имя администратора.")
+
+        if not errors:
+            updated_config = deepcopy(config_snapshot)
+            paths_cfg = updated_config.setdefault("paths", {})
+            paths_cfg["orders"] = orders_path
+            paths_cfg["facades_dir"] = facades_dir
+            paths_cfg["prisadka_root"] = prisadka_root
+            paths_cfg["desene_cpu_root"] = desene_cpu_root
+            paths_cfg["prisadka_client_root"] = prisadka_client_root
+            paths_cfg["facades_list_dir"] = facades_list_dir or facades_dir
+            paths_cfg["search"] = _parse_mapping(search_raw)
+
+            telegram_cfg = updated_config.setdefault("telegram", {})
+            telegram_cfg["token"] = telegram_token
+            telegram_cfg["chat_id"] = telegram_chat
+
+            updated_config["managers"] = manager_names
+            updated_config["technologists"] = {k: v for k, v in tech_markers.items() if k}
+
+            save_config(updated_config)
+            CONFIG.clear()
+            CONFIG.update(updated_config)
+            apply_config(CONFIG)
+
+            creation_errors: list[str] = []
+
+            admin_result = upsert_user(admin_username, admin_password, "admin")
+            if not admin_result.get("ok"):
+                creation_errors.append(admin_result.get("message", "Не удалось создать администратора."))
+
+            for item in managers:
+                result = upsert_user(item.get("username"), item.get("password"), "manager")
+                if not result.get("ok"):
+                    creation_errors.append(result.get("message", "Не удалось создать менеджера."))
+
+            for item in technologists:
+                result = upsert_user(item.get("username"), item.get("password"), "technologist")
+                if not result.get("ok"):
+                    creation_errors.append(result.get("message", "Не удалось создать технолога."))
+
+            if creation_errors:
+                errors.extend(creation_errors)
+                logger.warning("[setup] Ошибки создания пользователей: %s", creation_errors)
+            else:
+                flash(
+                    "Первичная настройка завершена. Авторизуйтесь с учётной записью администратора.",
+                    "success",
+                )
+                return redirect(url_for("auth.login"))
+
+    return render_template(
+        "setup.html",
+        errors=errors,
+        status_message=status_message,
+        config=config_snapshot,
+        managers_prefill=managers_form,
+        technologists_prefill=technologists_form,
+        search_text="\n".join(
+            f"{title}={path}" for title, path in (config_snapshot.get("paths", {}).get("search", {}) or {}).items()
+        ),
+    )
+
+
+__all__ = ["setup_bp"]

--- a/app/services/setup_state.py
+++ b/app/services/setup_state.py
@@ -1,0 +1,30 @@
+import logging
+
+import app.config as app_config
+from app.dal.users import count_active_admins, count_users
+
+logger = logging.getLogger("bazis")
+
+
+def is_first_run() -> bool:
+    """Определяет, требуется ли первичная настройка."""
+    try:
+        total_users = count_users()
+        admin_users = count_active_admins()
+    except Exception as exc:  # pragma: no cover - защитное логирование
+        logger.warning("[setup] Не удалось прочитать состояние пользователей", exc_info=exc)
+        return True
+
+    paths_cfg = app_config.CONFIG.get("paths", {}) if isinstance(app_config.CONFIG, dict) else {}
+    config_incomplete = not (paths_cfg.get("orders") or app_config.SEARCH_FOLDERS)
+
+    if total_users == 0 or admin_users == 0:
+        return True
+
+    if total_users == 1 and admin_users == 1 and config_incomplete:
+        return True
+
+    return False
+
+
+__all__ = ["is_first_run"]

--- a/app/services/snapshot.py
+++ b/app/services/snapshot.py
@@ -1,3 +1,4 @@
+import calendar
 import hashlib
 import os
 import re
@@ -7,6 +8,7 @@ import time
 from datetime import datetime
 from time import perf_counter
 from typing import Dict, List, Optional, Set, Tuple
+from zoneinfo import ZoneInfo
 
 import app as bazis_app
 import app.config as app_config
@@ -31,12 +33,40 @@ MONTHS_RO = {
     12: "12. Decembrie",
 }
 
+CHISINAU_TZ = ZoneInfo("Europe/Chisinau")
+
 
 def _format_modified(ts_value: float) -> str:
     try:
         return datetime.fromtimestamp(ts_value).strftime("%d.%m.%Y %H:%M")
     except Exception:
         return ""
+
+
+def _shift_months(dt: datetime, months_back: int) -> datetime:
+    """Сдвиг даты на указанное число календарных месяцев назад."""
+    assert months_back > 0, "period must be positive"
+    year = dt.year
+    month = dt.month - months_back
+    while month <= 0:
+        month += 12
+        year -= 1
+
+    last_day = calendar.monthrange(year, month)[1]
+    safe_day = min(dt.day, last_day)
+    return dt.replace(year=year, month=month, day=safe_day)
+
+
+def calculate_period_cutoff(months_back: int) -> float:
+    """Возвращает timestamp начала периода поиска с учётом часового пояса."""
+    months = max(1, months_back)
+    now = datetime.now(CHISINAU_TZ)
+    start_dt = _shift_months(now, months)
+    cutoff_ts = start_dt.timestamp()
+    logger.debug(
+        "[search] period cutoff %s months => %s", months, start_dt.isoformat()
+    )
+    return cutoff_ts
 
 
 def parse_folder_entry(
@@ -371,14 +401,14 @@ def collect_month_scope(months_back: Optional[int]) -> List[str]:
     if months_back is None:
         return get_recent_months()
 
-    limit: Optional[int]
+    raw_limit: Optional[int]
     if months_back == 0:
-        limit = None
+        raw_limit = None
     else:
         try:
-            limit = max(1, min(24, int(months_back)))
+            raw_limit = max(1, min(24, int(months_back)))
         except (TypeError, ValueError):
-            limit = None
+            raw_limit = None
 
     month_candidates: list[tuple[float, str]] = []
     seen: set[str] = set()
@@ -400,11 +430,15 @@ def collect_month_scope(months_back: Optional[int]) -> List[str]:
 
     month_candidates.sort(key=lambda item: item[0], reverse=True)
     ordered_months = [name for _, name in month_candidates]
-    if limit:
-        ordered_months = ordered_months[:limit]
+    effective_limit = None if raw_limit is None else min(24, raw_limit + 1)
+    if effective_limit:
+        ordered_months = ordered_months[:effective_limit]
 
     if not ordered_months:
-        return get_recent_months(months_back if months_back else None)
+        fallback = raw_limit if raw_limit is not None else months_back
+        if fallback:
+            fallback = min(24, fallback + 1)
+        return get_recent_months(fallback if fallback else None)
     return ordered_months
 
 
@@ -513,7 +547,9 @@ def refresh_search_index(full: bool = False, months_back: Optional[int] = None, 
 
 
 @measure_time("search")
-def search_in_index(query: str, months_scope: Optional[List[str]] = None):
+def search_in_index(
+    query: str, months_scope: Optional[List[str]] = None, cutoff_ts: Optional[float] = None
+):
     cleaned_query, month_filters = _extract_month_filters(query)
     normalized_query = (cleaned_query or "").strip().lower()
     keys = list(app_config.SEARCH_FOLDERS.keys())
@@ -531,7 +567,7 @@ def search_in_index(query: str, months_scope: Optional[List[str]] = None):
         "SELECT base_key, name, manager, path FROM search_index "
         "WHERE name_lc LIKE ?"
     )
-    params: List[str] = [f"%{normalized_query}%"]
+    params: List[object] = [f"%{normalized_query}%"]
 
     merged_filters = list(month_filters)
     if months_scope:
@@ -545,6 +581,10 @@ def search_in_index(query: str, months_scope: Optional[List[str]] = None):
         placeholders = ",".join("?" for _ in merged_filters)
         sql += f" AND month IN ({placeholders})"
         params.extend(merged_filters)
+
+    if cutoff_ts:
+        sql += " AND mtime_ts >= ?"
+        params.append(float(cutoff_ts))
 
     sql += " ORDER BY mtime_ts DESC"
 

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -1156,6 +1156,64 @@ const SearchPage = (() => {
   return { init };
 })();
 
+const SetupPage = (() => {
+  function init() {
+    const form = document.querySelector('[data-setup-form]');
+    if (!form) return;
+
+    bindRepeater('manager');
+    bindRepeater('technologist');
+  }
+
+  function bindRepeater(prefix) {
+    const container = document.querySelector(`[data-${prefix}-rows]`);
+    const addBtn = document.querySelector(`[data-add-${prefix}]`);
+    if (!container || !addBtn) return;
+
+    addBtn.addEventListener('click', (event) => {
+      event.preventDefault();
+      addRow(prefix, container);
+    });
+
+    container.addEventListener('click', (event) => {
+      const removeBtn = event.target.closest('[data-remove-row]');
+      if (!removeBtn) return;
+      const row = removeBtn.closest('[data-repeater-row]');
+      const rows = container.querySelectorAll('[data-repeater-row]');
+      if (row && rows.length > 1) {
+        row.remove();
+      }
+    });
+  }
+
+  function addRow(prefix, container) {
+    const row = document.createElement('div');
+    row.className = 'repeater-row';
+    row.setAttribute('data-repeater-row', '');
+
+    if (prefix === 'technologist') {
+      row.innerHTML = `
+        <input type="text" class="input" name="technologist_marker[]" placeholder="Маркер">
+        <input type="text" class="input" name="technologist_name[]" placeholder="Имя">
+        <input type="text" class="input" name="technologist_username[]" placeholder="Логин">
+        <input type="password" class="input" name="technologist_password[]" placeholder="Пароль">
+        <button type="button" class="btn btn--ghost" data-remove-row>✖</button>
+      `;
+    } else {
+      row.innerHTML = `
+        <input type="text" class="input" name="manager_name[]" placeholder="Имя для отображения">
+        <input type="text" class="input" name="manager_username[]" placeholder="Логин">
+        <input type="password" class="input" name="manager_password[]" placeholder="Пароль">
+        <button type="button" class="btn btn--ghost" data-remove-row>✖</button>
+      `;
+    }
+
+    container.appendChild(row);
+  }
+
+  return { init };
+})();
+
 const FacadesPage = (() => {
   function init() {
     const container = document.getElementById('facadeList');
@@ -1369,6 +1427,7 @@ document.addEventListener('DOMContentLoaded', () => {
   OrdersPage.init();
   ClientsPage.init();
   SearchPage.init();
+  SetupPage.init();
   FacadesPage.init();
   SettingsPage.init();
   UsersTable.init();

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -346,6 +346,10 @@ select:focus {
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
 
+.settings-grid--dense {
+  gap: 14px 18px;
+}
+
 .settings-field {
   display: flex;
   flex-direction: column;
@@ -365,6 +369,23 @@ select:focus {
   display: flex;
   justify-content: flex-end;
   gap: 12px;
+}
+
+.repeater {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.repeater-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)) auto;
+  gap: 10px;
+  align-items: center;
+}
+
+.repeater-row .btn {
+  margin-top: 0;
 }
 
 .notice-card {
@@ -485,6 +506,11 @@ select:focus {
   overflow: auto;
   border: 1px solid rgba(148, 163, 184, 0.2);
   border-radius: 12px;
+}
+
+.data-table--compact th,
+.data-table--compact td {
+  padding: 10px 12px;
 }
 
 .data-table {
@@ -689,6 +715,30 @@ select:focus {
   padding: 6px 12px;
   border-radius: 999px;
   font-weight: 600;
+}
+
+.clients-filter {
+  gap: 10px;
+  align-items: flex-end;
+  flex-wrap: wrap;
+}
+
+.clients-filter--compact {
+  align-items: center;
+  gap: 8px;
+}
+
+.clients-filter .input {
+  min-width: 220px;
+}
+
+.clients-filter__label {
+  margin-bottom: 0;
+  font-weight: 600;
+}
+
+.clients-col--name {
+  width: 38%;
 }
 
 .action-buttons {
@@ -1341,9 +1391,9 @@ code {
 }
 
 .role-card__body {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 10px 14px;
 }
 
 .role-card__title {
@@ -1371,12 +1421,14 @@ code {
 }
 
 .role-block {
-  padding: 12px 0;
-  border-top: 1px solid rgba(148, 163, 184, 0.25);
+  padding: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 12px;
+  background: #f8fafc;
 }
 
 .role-block:first-of-type {
-  border-top: 0;
+  border-top: 1px solid rgba(148, 163, 184, 0.2);
 }
 
 .role-block__title {
@@ -1387,8 +1439,58 @@ code {
 
 .role-block__grid {
   display: grid;
-  gap: 10px 14px;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 8px 12px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.manager-stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 10px;
+}
+
+.manager-stat {
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 14px;
+  padding: 10px 12px;
+  background: linear-gradient(180deg, rgba(248, 250, 252, 0.75) 0%, #fff 100%);
+  display: grid;
+  gap: 4px;
+  justify-items: center;
+}
+
+.manager-stat__header {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+
+.manager-stat__value {
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.manager-stat__hint {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.manager-stat__empty {
+  padding: 12px;
+  text-align: center;
+}
+
+.manager-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--primary);
+  font-weight: 700;
 }
 /* Confirmation modal */
 .confirm-overlay {

--- a/app/templates/clients.html
+++ b/app/templates/clients.html
@@ -30,12 +30,49 @@ data-managers="{{ config_managers | join(',') }}"
     </form>
   </section>
 
+  <section class="card">
+    <div class="card-header-between">
+      <h2 class="section-title">Поиск по клиентам</h2>
+      <p class="hint">Поиск работает по части имени, без учёта регистра.</p>
+    </div>
+    <form method="get" class="form-inline clients-filter clients-filter--compact">
+      <label class="field-label clients-filter__label" for="client_query">Имя клиента</label>
+      <input type="text" name="q" id="client_query" class="input input--compact" value="{{ search_query }}" placeholder="Начните вводить имя...">
+      <button type="submit" class="btn btn--primary">Искать</button>
+      {% if search_query %}
+      <a href="{{ url_for('clients.clients_page') }}" class="btn btn--ghost">Сбросить</a>
+      {% endif %}
+    </form>
+  </section>
+
+  <section class="card table-card">
+    <div class="card-header-between">
+      <h2 class="section-title">Клиенты по менеджерам</h2>
+      <p class="hint">Компактная статистика распределения клиентов.</p>
+    </div>
+    <div class="manager-stats-grid">
+      {% if manager_stats %}
+        {% for manager_name, client_count in manager_stats %}
+        <div class="manager-stat">
+          <div class="manager-stat__header">
+            <span class="manager-pill">{{ manager_name or 'Неизвестно' }}</span>
+          </div>
+          <div class="manager-stat__value">{{ client_count }}</div>
+          <p class="manager-stat__hint">клиентов</p>
+        </div>
+        {% endfor %}
+      {% else %}
+        <div class="table-secondary manager-stat__empty">Данные отсутствуют.</div>
+      {% endif %}
+    </div>
+  </section>
+
   <section class="card table-card clients-table">
     <div class="table-scroll">
       <table class="data-table" data-clients-table>
         <thead>
           <tr>
-            <th>Клиент</th>
+            <th class="clients-col--name">Клиент</th>
             <th>Менеджер</th>
             <th>Действия</th>
           </tr>

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -75,7 +75,7 @@ data-managers="{{ config_managers | join(',') }}"
     <h2 class="section-title">Конфигурация</h2>
     <form method="POST" class="settings-form">
       {% if role_perms.can_edit_paths %}
-      <div class="settings-grid">
+      <div class="settings-grid settings-grid--dense">
         <div class="settings-field settings-field--wide">
           <label class="field-label" for="orders_path">Путь к папке заказов</label>
           <input type="text" class="input" id="orders_path" name="orders_path" placeholder="\\\\SERVER\\share" value="{{ config.get('paths', {}).get('orders', '') }}">
@@ -88,7 +88,8 @@ data-managers="{{ config_managers | join(',') }}"
 
         <div class="settings-field settings-field--wide">
           <label class="field-label" for="search_folders">Папки для поиска (Название=Путь)</label>
-          <textarea id="search_folders" name="search_folders" class="input" placeholder="Название=\\\\SERVER\\path">{{ search_text }}</textarea>
+          <textarea id="search_folders" name="search_folders" class="input input--mono" placeholder="Название=\\\\SERVER\\path">{{ search_text }}</textarea>
+          <p class="hint">Используйте по одному пути в строке: <code>Название=\\\\server\\share</code>.</p>
         </div>
 
         <div class="settings-field">

--- a/app/templates/setup.html
+++ b/app/templates/setup.html
@@ -1,0 +1,140 @@
+{% extends "base.html" %}
+
+{% block title %}Первичная настройка{% endblock %}
+
+{% block content %}
+  <header class="page-header">
+    <h1>🚀 Первичная настройка</h1>
+    <p class="page-description">
+      Укажите ключевые пути, данные Telegram и создайте первые учётные записи. Эта страница доступна только до завершения установки.
+    </p>
+  </header>
+
+  {% if errors %}
+  <section class="notice-card notice-card--error">
+    <strong>Исправьте ошибки:</strong>
+    <ul>
+      {% for error in errors %}
+      <li>{{ error }}</li>
+      {% endfor %}
+    </ul>
+  </section>
+  {% endif %}
+
+  {% if status_message %}
+  <section class="notice-card notice-card--success">{{ status_message }}</section>
+  {% endif %}
+
+  <section class="card">
+    <form method="post" class="settings-form" data-setup-form>
+      <h2 class="section-title">Файловые пути</h2>
+      <div class="settings-grid">
+        <div class="settings-field settings-field--wide">
+          <label class="field-label" for="orders_path">Путь к папке заказов</label>
+          <input type="text" class="input" id="orders_path" name="orders_path" placeholder="\\\\SERVER\\orders" value="{{ config.get('paths', {}).get('orders', '') }}">
+        </div>
+        <div class="settings-field settings-field--wide">
+          <label class="field-label" for="facades_dir">Папка для Facades_list</label>
+          <input type="text" class="input" id="facades_dir" name="facades_dir" placeholder="\\\\SERVER\\facades" value="{{ config.get('paths', {}).get('facades_dir', '') }}">
+        </div>
+        <div class="settings-field settings-field--wide">
+          <label class="field-label" for="prisadka_root">Присадка root path</label>
+          <input type="text" class="input" id="prisadka_root" name="prisadka_root" placeholder="\\\\SERVER\\prisadka" value="{{ config.get('paths', {}).get('prisadka_root', '') }}">
+        </div>
+        <div class="settings-field settings-field--wide">
+          <label class="field-label" for="desene_cpu_root">DESENE CPU root path</label>
+          <input type="text" class="input" id="desene_cpu_root" name="desene_cpu_root" placeholder="\\\\SERVER\\desene" value="{{ config.get('paths', {}).get('desene_cpu_root', '') }}">
+        </div>
+        <div class="settings-field settings-field--wide">
+          <label class="field-label" for="prisadka_client_root">Присадка Клиента root path</label>
+          <input type="text" class="input" id="prisadka_client_root" name="prisadka_client_root" placeholder="\\\\SERVER\\client_prisadka" value="{{ config.get('paths', {}).get('prisadka_client_root', '') }}">
+        </div>
+        <div class="settings-field settings-field--wide">
+          <label class="field-label" for="facades_list_dir">Папка для Facades_list (отдельно)</label>
+          <input type="text" class="input" id="facades_list_dir" name="facades_list_dir" placeholder="\\\\SERVER\\facades_list" value="{{ config.get('paths', {}).get('facades_list_dir', '') }}">
+        </div>
+        <div class="settings-field settings-field--wide">
+          <label class="field-label" for="search_folders">Папки поиска (Название=Путь)</label>
+          <textarea id="search_folders" name="search_folders" class="input" placeholder="Архив=\\\\SERVER\\archive">{{ search_text }}</textarea>
+        </div>
+      </div>
+
+      <h2 class="section-title">Telegram</h2>
+      <div class="settings-grid">
+        <div class="settings-field">
+          <label class="field-label" for="telegram_token">Telegram Bot Token</label>
+          <input type="text" class="input" id="telegram_token" name="telegram_token" placeholder="000000:ABC" value="{{ config.get('telegram', {}).get('token', '') }}">
+        </div>
+        <div class="settings-field">
+          <label class="field-label" for="telegram_chat_id">Telegram Chat ID</label>
+          <input type="text" class="input" id="telegram_chat_id" name="telegram_chat_id" placeholder="123456789" value="{{ config.get('telegram', {}).get('chat_id', '') }}">
+        </div>
+      </div>
+
+      <h2 class="section-title">Пользователи</h2>
+      <div class="card card--subtle">
+        <div class="settings-grid">
+          <div class="settings-field">
+            <label class="field-label" for="admin_username">Логин администратора</label>
+            <input type="text" class="input" id="admin_username" name="admin_username" required>
+          </div>
+          <div class="settings-field">
+            <label class="field-label" for="admin_password">Пароль администратора</label>
+            <input type="password" class="input" id="admin_password" name="admin_password" required>
+          </div>
+          <div class="settings-field settings-field--wide">
+            <label class="field-label" for="admin_display">Отображаемое имя (опционально)</label>
+            <input type="text" class="input" id="admin_display" name="admin_display" placeholder="Главный администратор">
+          </div>
+        </div>
+      </div>
+
+      <div class="card card--subtle">
+        <div class="card-header-between">
+          <div>
+            <h3 class="section-title">Менеджеры</h3>
+            <p class="hint">Добавьте учётные записи менеджеров. Поля логина и пароля обязательны.</p>
+          </div>
+          <button type="button" class="btn btn--ghost" data-add-manager>➕ Добавить менеджера</button>
+        </div>
+        <div class="repeater" data-manager-rows>
+          {% set managers_list = managers_prefill if managers_prefill else [{}] %}
+          {% for row in managers_list %}
+          <div class="repeater-row" data-repeater-row>
+            <input type="text" class="input" name="manager_name[]" placeholder="Имя для отображения" value="{{ row.name or '' }}">
+            <input type="text" class="input" name="manager_username[]" placeholder="Логин" value="{{ row.username or '' }}">
+            <input type="password" class="input" name="manager_password[]" placeholder="Пароль" value="{{ row.password or '' }}">
+            <button type="button" class="btn btn--ghost" data-remove-row>✖</button>
+          </div>
+          {% endfor %}
+        </div>
+      </div>
+
+      <div class="card card--subtle">
+        <div class="card-header-between">
+          <div>
+            <h3 class="section-title">Технологи</h3>
+            <p class="hint">Укажите маркер (для распознавания), логин и пароль.</p>
+          </div>
+          <button type="button" class="btn btn--ghost" data-add-technologist>➕ Добавить технолога</button>
+        </div>
+        <div class="repeater" data-technologist-rows>
+          {% set technologists_list = technologists_prefill if technologists_prefill else [{}] %}
+          {% for row in technologists_list %}
+          <div class="repeater-row" data-repeater-row>
+            <input type="text" class="input" name="technologist_marker[]" placeholder="Маркер" value="{{ row.marker or '' }}">
+            <input type="text" class="input" name="technologist_name[]" placeholder="Имя" value="{{ row.name or '' }}">
+            <input type="text" class="input" name="technologist_username[]" placeholder="Логин" value="{{ row.username or '' }}">
+            <input type="password" class="input" name="technologist_password[]" placeholder="Пароль" value="{{ row.password or '' }}">
+            <button type="button" class="btn btn--ghost" data-remove-row>✖</button>
+          </div>
+          {% endfor %}
+        </div>
+      </div>
+
+      <div class="settings-actions">
+        <button type="submit" class="btn btn--primary">💾 Сохранить и продолжить</button>
+      </div>
+    </form>
+  </section>
+{% endblock %}


### PR DESCRIPTION
## Summary
- simplify settings paths to focus on orders folder, facades_list.txt, and clearer search folder inputs
- tighten clients search layout, narrow name column, and render manager statistics as compact cards
- refresh role permissions grid with denser, horizontal cards aligned to the home page styling

## Testing
- python -m compileall app


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d41986a1c832db7d23126bce6b50b)