### PR TITLE
Wave 3 UI and permissions fixes

### DIFF
--- a/app/routes/settings.py
+++ b/app/routes/settings.py
@@ -304,6 +304,14 @@ def _json_data() -> dict:
     return request.form.to_dict()
 
 
+def _checkbox_enabled(form, key: str) -> bool:
+    """Надёжно определяет состояние чекбокса с парой hidden+checkbox."""
+    values = [str(value).strip().lower() for value in form.getlist(key)]
+    if not values:
+        return False
+    return any(value in {"1", "true", "on", "yes"} for value in values)
+
+
 def _build_response(result: dict):
     if result.get("ok"):
         return {"status": "ok"}, 200
@@ -389,15 +397,16 @@ def change_user_password():
 @permissions_required("can_access_settings", "can_manage_users")
 def update_role_permissions():
     role_names = {name.strip().lower() for name in request.form.getlist("role_names[]") if name}
+    existing = get_all_role_permissions()
     if not role_names:
-        role_names = set(get_all_role_permissions().keys())
+        role_names = set(existing.keys())
 
     updates = {}
     for role in role_names:
         perms = {}
         for field in PERMISSION_FIELDS:
             key = f"roles[{role}][{field}]"
-            perms[field] = 1 if request.form.get(key) else 0
+            perms[field] = 1 if _checkbox_enabled(request.form, key) else 0
         updates[role] = perms
 
     updates.setdefault("admin", {})
@@ -416,9 +425,7 @@ def update_role_permissions():
 @permissions_required("can_access_settings", "can_manage_users")
 def create_role_entry():
     role_name = (request.form.get("role_name") or "").strip()
-    perms = {
-        field: 1 if request.form.get(f"new_role[{field}]") else 0 for field in PERMISSION_FIELDS
-    }
+    perms = {field: 1 if _checkbox_enabled(request.form, f"new_role[{field}]") else 0 for field in PERMISSION_FIELDS}
 
     result = create_role(role_name, perms)
     if request.is_json or request.headers.get("X-Requested-With") == "XMLHttpRequest":

--- a/app/routes/setup.py
+++ b/app/routes/setup.py
@@ -25,19 +25,6 @@ def enforce_setup_wizard():
         return redirect(url_for("auth.login"))
 
 
-def _parse_mapping(value: str) -> dict:
-    mapping = {}
-    for line in value.splitlines():
-        if "=" not in line:
-            continue
-        key, val = line.split("=", 1)
-        key = key.strip()
-        val = val.strip()
-        if key and val:
-            mapping[key] = val
-    return mapping
-
-
 def _collect_accounts(prefix: str) -> list[dict]:
     names = request.form.getlist(f"{prefix}_name[]")
     logins = request.form.getlist(f"{prefix}_username[]")
@@ -80,13 +67,7 @@ def setup_page():
     technologists_form = _collect_accounts("technologist") if request.method == "POST" else []
 
     if request.method == "POST":
-        orders_path = request.form.get("orders_path", "").strip()
         facades_dir = request.form.get("facades_dir", "").strip()
-        prisadka_root = request.form.get("prisadka_root", "").strip()
-        desene_cpu_root = request.form.get("desene_cpu_root", "").strip()
-        prisadka_client_root = request.form.get("prisadka_client_root", "").strip()
-        facades_list_dir = request.form.get("facades_list_dir", "").strip()
-        search_raw = request.form.get("search_folders", "")
 
         telegram_token = request.form.get("telegram_token", "").strip()
         telegram_chat = request.form.get("telegram_chat_id", "").strip()
@@ -96,13 +77,9 @@ def setup_page():
         admin_display = (request.form.get("admin_display") or "").strip()
 
         paths_snapshot = config_snapshot.setdefault("paths", {})
-        paths_snapshot["orders"] = orders_path
-        paths_snapshot["facades_dir"] = facades_dir
-        paths_snapshot["prisadka_root"] = prisadka_root
-        paths_snapshot["desene_cpu_root"] = desene_cpu_root
-        paths_snapshot["prisadka_client_root"] = prisadka_client_root
-        paths_snapshot["facades_list_dir"] = facades_list_dir
-        paths_snapshot["search"] = _parse_mapping(search_raw)
+        if facades_dir:
+            paths_snapshot["facades_dir"] = facades_dir
+            paths_snapshot["facades_list_dir"] = facades_dir
 
         telegram_snapshot = config_snapshot.setdefault("telegram", {})
         telegram_snapshot["token"] = telegram_token
@@ -135,13 +112,9 @@ def setup_page():
         if not errors:
             updated_config = deepcopy(config_snapshot)
             paths_cfg = updated_config.setdefault("paths", {})
-            paths_cfg["orders"] = orders_path
-            paths_cfg["facades_dir"] = facades_dir
-            paths_cfg["prisadka_root"] = prisadka_root
-            paths_cfg["desene_cpu_root"] = desene_cpu_root
-            paths_cfg["prisadka_client_root"] = prisadka_client_root
-            paths_cfg["facades_list_dir"] = facades_list_dir or facades_dir
-            paths_cfg["search"] = _parse_mapping(search_raw)
+            if facades_dir:
+                paths_cfg["facades_dir"] = facades_dir
+                paths_cfg["facades_list_dir"] = facades_dir
 
             telegram_cfg = updated_config.setdefault("telegram", {})
             telegram_cfg["token"] = telegram_token
@@ -197,9 +170,6 @@ def setup_page():
         config=config_snapshot,
         managers_prefill=managers_form,
         technologists_prefill=technologists_form,
-        search_text="\n".join(
-            f"{title}={path}" for title, path in (config_snapshot.get("paths", {}).get("search", {}) or {}).items()
-        ),
     )
 
 

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -116,6 +116,8 @@ const OrdersPage = (() => {
     APP_CONFIG.currentRole === 'manager' && APP_CONFIG.currentUser
       ? APP_CONFIG.currentUser
       : 'Все';
+  let searchTerm = '';
+  let searchTimer = null;
   let sortKey = null;
   let sortOrder = 1;
   let sse = null;
@@ -146,6 +148,10 @@ const OrdersPage = (() => {
     const managerSelect = document.getElementById('managerSelect');
     if (managerSelect && currentManager !== 'Все') {
       managerSelect.value = currentManager;
+    }
+    const searchInput = document.getElementById('orderSearch');
+    if (searchInput) {
+      searchInput.addEventListener('input', () => handleSearchInput(searchInput.value));
     }
     if (APP_CONFIG.permissions.canViewPricedPanel) {
       initBellWidget();
@@ -250,6 +256,17 @@ const OrdersPage = (() => {
     currentStatus = status;
     highlightActiveFilter(status);
     render();
+  }
+
+  function handleSearchInput(value) {
+    const normalized = (value || '').trim().toLowerCase();
+    if (searchTimer) {
+      clearTimeout(searchTimer);
+    }
+    searchTimer = setTimeout(() => {
+      searchTerm = normalized;
+      render();
+    }, 180);
   }
 
   function setManagerFilter() {
@@ -385,6 +402,11 @@ const OrdersPage = (() => {
           return item.status === 'Готов' || item.status === 'Подтвержден';
         }
         return item.status === currentStatus;
+      })
+      .filter(item => {
+        if (!searchTerm) return true;
+        const orderName = (item.name || '').toLowerCase();
+        return orderName.includes(searchTerm);
       })
       .slice();
 
@@ -714,10 +736,12 @@ const OrdersPage = (() => {
       bell.panel.removeAttribute('hidden');
       requestAnimationFrame(() => bell.panel.classList.add('is-open'));
       bell.toggle.setAttribute('aria-expanded', 'true');
+      bell.toggle.classList.add('is-active');
     } else {
       bell.panel.classList.remove('is-open');
       bell.panel.classList.add('is-closing');
       bell.toggle.setAttribute('aria-expanded', 'false');
+      bell.toggle.classList.remove('is-active');
       setTimeout(() => {
         bell.panel.classList.remove('is-closing');
         bell.panel.setAttribute('hidden', '');

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -119,6 +119,13 @@ h1 {
   align-items: flex-end;
 }
 
+.filter-search {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 220px;
+}
+
 .button-group {
   display: flex;
   flex-wrap: wrap;
@@ -850,6 +857,40 @@ select:focus {
   font-size: 1.2rem;
 }
 
+@media (prefers-reduced-motion: no-preference) {
+  .bell-button .bell-icon {
+    display: inline-block;
+    transform-origin: top center;
+  }
+
+  .bell-button:hover .bell-icon,
+  .bell-button:focus-visible .bell-icon,
+  .bell-button.is-active .bell-icon {
+    animation: bell-ring 0.9s ease-in-out;
+  }
+
+  @keyframes bell-ring {
+    0% {
+      transform: rotate(0deg);
+    }
+    20% {
+      transform: rotate(-12deg);
+    }
+    40% {
+      transform: rotate(10deg);
+    }
+    60% {
+      transform: rotate(-6deg);
+    }
+    80% {
+      transform: rotate(4deg);
+    }
+    100% {
+      transform: rotate(0deg);
+    }
+  }
+}
+
 .bell-badge {
   position: absolute;
   top: -8px;
@@ -1563,6 +1604,19 @@ code {
   grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
 }
 
+.roles-layout {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
+  gap: 18px;
+  align-items: start;
+}
+
+.role-card {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
 .role-card {
   border: 1px solid rgba(148, 163, 184, 0.35);
   border-radius: 16px;
@@ -1589,6 +1643,7 @@ code {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
   gap: 10px 14px;
+  flex: 1;
 }
 
 /* Wrap permissions form to mirror role cards layout */
@@ -1612,6 +1667,15 @@ code {
   border-top: 1px solid rgba(148, 163, 184, 0.25);
   padding-top: 12px;
   margin-top: 16px;
+}
+
+.role-card__footer--sticky {
+  border-top: 1px solid rgba(148, 163, 184, 0.18);
+  padding-top: 12px;
+  margin-top: 18px;
+  position: sticky;
+  bottom: 0;
+  background: linear-gradient(180deg, rgba(248, 250, 252, 0.9) 0%, #fff 100%);
 }
 
 .role-card__title {
@@ -1659,6 +1723,10 @@ code {
   display: grid;
   gap: 8px 12px;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.role-grid--cards {
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
 }
 
 .manager-stats-grid {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -38,6 +38,10 @@ data-order-confirmation="{{ 'true' if order_confirmation_enabled else 'false' }}
             <option value="Неизвестно">Неизвестно</option>
           </select>
         </label>
+        <div class="filter-search">
+          <label class="field-label" for="orderSearch">Поиск по названию</label>
+          <input type="search" id="orderSearch" class="input input--compact" placeholder="Начните ввод" autocomplete="off">
+        </div>
         <div class="button-group">
           <button type="button" class="btn btn--ghost" data-sort="status" onclick="sortBy('status')">⇅ Статус</button>
           <button type="button" class="btn btn--ghost" data-sort="days" onclick="sortBy('days')">⇅ Давность</button>

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -423,17 +423,17 @@ data-managers='{{ config_managers | tojson }}'
       <span class="text-muted">Изменения сохраняются одной кнопкой.</span>
     </div>
 
-    <div class="role-grid">
-      <article class="role-card">
+    <div class="roles-layout">
+      <article class="role-card role-card--creation">
         <header class="role-card__header">
           <div>
             <span class="role-card__title">Добавить новую роль</span>
             <p class="role-card__hint">Укажите имя и включите базовые права.</p>
           </div>
         </header>
-        <form action="{{ url_for('settings.create_role_entry') }}" method="POST" class="role-card__body">
+        <form action="{{ url_for('settings.create_role_entry') }}" method="POST" class="role-card__body" id="createRoleForm">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-		  <div class="role-block">
+                  <div class="role-block">
             <label class="field-label" for="role_name">Название роли</label>
             <input type="text" id="role_name" name="role_name" class="input" placeholder="например, auditor" required>
           </div>
@@ -443,6 +443,7 @@ data-managers='{{ config_managers | tojson }}'
             <div class="role-block__grid">
               {% for field, label, desc in fields %}
               <label class="checkbox-row">
+                <input type="hidden" name="new_role[{{ field }}]" value="0">
                 <input type="checkbox" name="new_role[{{ field }}]" value="1">
                 <div class="checkbox-row__content">
                   <span class="checkbox-row__label">{{ label }}</span>
@@ -458,58 +459,59 @@ data-managers='{{ config_managers | tojson }}'
           </div>
         </form>
       </article>
-    </div>
 
-    <form action="{{ url_for('settings.update_role_permissions') }}" method="POST" class="role-editor role-cards-form">
-      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-	  <div class="role-grid">
-        {% for role, perms in role_permissions | dictsort %}
-        <article class="role-card">
-          <header class="role-card__header">
-            <div>
-              <span class="role-badge">{{ role }}</span>
-              <span class="role-card__title">{{ role_titles.get(role, role|capitalize) }}</span>
-            </div>
-            <div class="role-card__actions">
-              <input type="hidden" name="role_names[]" value="{{ role }}">
-              {% if role not in protected_roles %}
-                {% if role in role_usage %}
-                  <button type="button" class="btn btn--ghost" disabled>Используется</button>
-                {% else %}
-                  <button type="submit" class="btn btn--ghost" formaction="{{ url_for('settings.delete_role_entry', role=role) }}" formmethod="post" formnovalidate onclick="return confirm('Удалить роль «{{ role }}»?')">Удалить</button>
-                {% endif %}
-              {% else %}
-                <span class="role-card__hint">Системная роль</span>
-              {% endif %}
-            </div>
-          </header>
-
-          <div class="role-card__body">
-            {% for group_title, fields in permission_groups %}
-            <div class="role-block">
-              <h3 class="role-block__title">{{ group_title }}</h3>
-              <div class="role-block__grid">
-                {% for field, label, desc in fields %}
-                <label class="checkbox-row">
-                  <input type="checkbox" name="roles[{{ role }}][{{ field }}]" value="1" {% if perms.get(field) %}checked{% endif %}>
-                  <div class="checkbox-row__content">
-                    <span class="checkbox-row__label">{{ label }}</span>
-                    <span class="checkbox-row__desc">{{ desc }}</span>
-                  </div>
-                </label>
-                {% endfor %}
+      <form action="{{ url_for('settings.update_role_permissions') }}" method="POST" class="role-editor role-cards-form" id="rolePermissionsForm">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+              <div class="role-grid role-grid--cards">
+          {% for role, perms in role_permissions | dictsort %}
+          <article class="role-card">
+            <header class="role-card__header">
+              <div>
+                <span class="role-badge">{{ role }}</span>
+                <span class="role-card__title">{{ role_titles.get(role, role|capitalize) }}</span>
               </div>
-            </div>
-            {% endfor %}
-          </div>
-        </article>
-        {% endfor %}
-      </div>
+              <div class="role-card__actions">
+                <input type="hidden" name="role_names[]" value="{{ role }}">
+                {% if role not in protected_roles %}
+                  {% if role in role_usage %}
+                    <button type="button" class="btn btn--ghost" disabled>Используется</button>
+                  {% else %}
+                    <button type="submit" class="btn btn--ghost" formaction="{{ url_for('settings.delete_role_entry', role=role) }}" formmethod="post" formnovalidate onclick="return confirm('Удалить роль «{{ role }}»?')">Удалить</button>
+                  {% endif %}
+                {% else %}
+                  <span class="role-card__hint">Системная роль</span>
+                {% endif %}
+              </div>
+            </header>
 
-      <div class="role-card__footer">
-        <button type="submit" class="btn btn--primary btn--pill">💾 Сохранить права</button>
-      </div>
-    </form>
+            <div class="role-card__body">
+              {% for group_title, fields in permission_groups %}
+              <div class="role-block">
+                <h3 class="role-block__title">{{ group_title }}</h3>
+                <div class="role-block__grid">
+                  {% for field, label, desc in fields %}
+                  <label class="checkbox-row">
+                    <input type="hidden" name="roles[{{ role }}][{{ field }}]" value="0">
+                    <input type="checkbox" name="roles[{{ role }}][{{ field }}]" value="1" {% if perms.get(field) %}checked{% endif %}>
+                    <div class="checkbox-row__content">
+                      <span class="checkbox-row__label">{{ label }}</span>
+                      <span class="checkbox-row__desc">{{ desc }}</span>
+                    </div>
+                  </label>
+                  {% endfor %}
+                </div>
+              </div>
+              {% endfor %}
+            </div>
+          </article>
+          {% endfor %}
+        </div>
+
+        <div class="role-card__footer role-card__footer--sticky">
+          <button type="submit" class="btn btn--primary btn--pill">💾 Сохранить права</button>
+        </div>
+      </form>
+    </div>
   </section>
   {% endif %}
 {% endblock %}

--- a/app/templates/setup.html
+++ b/app/templates/setup.html
@@ -28,35 +28,12 @@
   <section class="card">
     <form method="post" class="settings-form" data-setup-form>
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-	  <h2 class="section-title">Файловые пути</h2>
+          <h2 class="section-title">Файловый путь</h2>
       <div class="settings-grid">
         <div class="settings-field settings-field--wide">
-          <label class="field-label" for="orders_path">Путь к папке заказов</label>
-          <input type="text" class="input" id="orders_path" name="orders_path" placeholder="\\\\SERVER\\orders" value="{{ config.get('paths', {}).get('orders', '') }}">
-        </div>
-        <div class="settings-field settings-field--wide">
-          <label class="field-label" for="facades_dir">Папка для Facades_list</label>
+          <label class="field-label" for="facades_dir">Папка для facades_list.txt</label>
           <input type="text" class="input" id="facades_dir" name="facades_dir" placeholder="\\\\SERVER\\facades" value="{{ config.get('paths', {}).get('facades_dir', '') }}">
-        </div>
-        <div class="settings-field settings-field--wide">
-          <label class="field-label" for="prisadka_root">Присадка root path</label>
-          <input type="text" class="input" id="prisadka_root" name="prisadka_root" placeholder="\\\\SERVER\\prisadka" value="{{ config.get('paths', {}).get('prisadka_root', '') }}">
-        </div>
-        <div class="settings-field settings-field--wide">
-          <label class="field-label" for="desene_cpu_root">DESENE CPU root path</label>
-          <input type="text" class="input" id="desene_cpu_root" name="desene_cpu_root" placeholder="\\\\SERVER\\desene" value="{{ config.get('paths', {}).get('desene_cpu_root', '') }}">
-        </div>
-        <div class="settings-field settings-field--wide">
-          <label class="field-label" for="prisadka_client_root">Присадка Клиента root path</label>
-          <input type="text" class="input" id="prisadka_client_root" name="prisadka_client_root" placeholder="\\\\SERVER\\client_prisadka" value="{{ config.get('paths', {}).get('prisadka_client_root', '') }}">
-        </div>
-        <div class="settings-field settings-field--wide">
-          <label class="field-label" for="facades_list_dir">Папка для Facades_list (отдельно)</label>
-          <input type="text" class="input" id="facades_list_dir" name="facades_list_dir" placeholder="\\\\SERVER\\facades_list" value="{{ config.get('paths', {}).get('facades_list_dir', '') }}">
-        </div>
-        <div class="settings-field settings-field--wide">
-          <label class="field-label" for="search_folders">Папки поиска (Название=Путь)</label>
-          <textarea id="search_folders" name="search_folders" class="input" placeholder="Архив=\\\\SERVER\\archive">{{ search_text }}</textarea>
+          <p class="hint">Используется для генерации тестового документа на странице «Фасады».</p>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- fix role permission checkboxes to persist off/on states and keep enforcement
- simplify setup wizard paths while keeping facades export path configurable and refresh roles layout
- add compact order name search with subtle bell animation adjustments

## Testing
- python -m compileall app

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941c5ddb418832d8afb1fe579f40b21)