### PR TITLE
Add frontend micro-animations and UI polish

### DIFF
--- a/app/static/script.js
+++ b/app/static/script.js
@@ -43,6 +43,9 @@ const APP_CONFIG = (() => {
   return { managers, orderConfirmationEnabled, currentUser, currentRole, permissions };
 })();
 
+const PREFERS_REDUCED_MOTION = typeof window !== 'undefined'
+  && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
 const CSRF_TOKEN = (document.querySelector('meta[name="csrf-token"]')?.content
   || document.body?.dataset?.csrfToken
   || '').trim();
@@ -123,15 +126,17 @@ const OrdersPage = (() => {
   let sse = null;
   let pollingTimer = null;
   let pollingBackoff = 3000;
-  let managerPriced = new Set();
-  let pricedMap = {};
-  let pendingOrders = [];
-  let pendingRefreshTimer = null;
-  let bell = {
-    root: null,
-    badge: null,
-    panel: null,
-    list: null,
+    let managerPriced = new Set();
+    let pricedMap = {};
+    let pendingOrders = [];
+    let pendingRefreshTimer = null;
+    let previousOrders = new Map();
+    let sseStatus = { root: null, dot: null, text: null };
+    let bell = {
+      root: null,
+      badge: null,
+      panel: null,
+      list: null,
     empty: null,
     toggle: null,
   };
@@ -139,6 +144,10 @@ const OrdersPage = (() => {
   function init() {
     const table = document.getElementById('orders');
     if (!table) return;
+
+    sseStatus.root = document.getElementById('sseStatus');
+    sseStatus.dot = sseStatus.root?.querySelector('.sse-status__dot') || null;
+    sseStatus.text = sseStatus.root?.querySelector('.sse-status__text') || null;
 
     hydratePricedFromEmbedded();
     hydratePricedMapFromEmbedded();
@@ -152,6 +161,8 @@ const OrdersPage = (() => {
     const searchInput = document.getElementById('orderSearch');
     if (searchInput) {
       searchInput.addEventListener('input', () => handleSearchInput(searchInput.value));
+      searchInput.addEventListener('focus', () => searchInput.classList.add('is-focused'));
+      searchInput.addEventListener('blur', () => searchInput.classList.remove('is-focused'));
     }
     if (APP_CONFIG.permissions.canViewPricedPanel) {
       initBellWidget();
@@ -178,8 +189,13 @@ const OrdersPage = (() => {
     stopSSE();
     stopPollingFallback();
 
+    updateSseIndicator('reconnect', 'Подключение…');
     const streamUrl = `/events?${buildManagerParams().toString()}`;
     sse = new EventSource(streamUrl);
+
+    sse.onopen = () => {
+      updateSseIndicator('ok', 'Онлайн');
+    };
 
     sse.onmessage = ev => {
       pollingBackoff = 5000;
@@ -202,6 +218,7 @@ const OrdersPage = (() => {
     sse.onerror = () => {
       stopSSE();
       startPollingFallback();
+      updateSseIndicator('error', 'Офлайн');
     };
   }
 
@@ -231,6 +248,22 @@ const OrdersPage = (() => {
     pollingBackoff = 5000;
   }
 
+  function updateSseIndicator(state, label) {
+    if (!sseStatus.root) return;
+    sseStatus.root.classList.remove('sse-status--ok', 'sse-status--error', 'sse-status--reconnect');
+    if (state === 'ok') {
+      sseStatus.root.classList.add('sse-status--ok');
+    } else if (state === 'error') {
+      sseStatus.root.classList.add('sse-status--error');
+    } else {
+      sseStatus.root.classList.add('sse-status--reconnect');
+    }
+
+    if (sseStatus.text && label) {
+      sseStatus.text.textContent = label;
+    }
+  }
+
   function updateDataFromPayload(payload) {
     const orders = Array.isArray(payload?.orders)
       ? payload.orders
@@ -238,6 +271,7 @@ const OrdersPage = (() => {
         ? payload.folders
         : [];
 
+    previousOrders = new Map((allData || []).map(item => [getOrderKey(item), item]));
     allData = orders;
     render();
     renderStats({ ...payload, folders: orders });
@@ -432,112 +466,170 @@ const OrdersPage = (() => {
       });
     }
 
-    table.innerHTML = '';
+    const existingRows = new Map();
+    table.querySelectorAll('tr').forEach(row => {
+      const key = row.dataset.orderKey || row.dataset.key || row.dataset.client;
+      existingRows.set(key, row);
+    });
+
+    const newRows = [];
 
     filtered.forEach(item => {
-      const tr = document.createElement('tr');
-      if (item.status === 'Готов') {
-        tr.classList.add('done');
-      } else if (item.status === 'Подтвержден') {
-        tr.classList.add('confirmed');
-      } else {
-        tr.classList.add('new');
+      const key = getOrderKey(item);
+      let row = existingRows.get(key);
+      const prev = previousOrders.get(key);
+
+      if (!row) {
+        row = document.createElement('tr');
+        row.dataset.orderKey = key;
+        row.classList.add('is-entering');
+        if (!PREFERS_REDUCED_MOTION) {
+          requestAnimationFrame(() => row.classList.add('is-visible'));
+        } else {
+          row.classList.add('is-visible');
+        }
       }
 
-      let statusClass = 'status-pill status-pill--warning';
-      if (item.status === 'Готов') {
-        statusClass = 'status-pill status-pill--success';
-      } else if (item.status === 'Подтвержден') {
-        statusClass = 'status-pill status-pill--neutral';
+      fillOrderRow(row, item, allowConfirmationUI);
+
+      if (prev && hasOrderChanged(prev, item)) {
+        row.classList.add('is-updated');
+        setTimeout(() => row.classList.remove('is-updated'), 1100);
       }
 
-      const nameTd = document.createElement('td');
-      const nameDiv = document.createElement('div');
-      nameDiv.className = 'table-primary';
+      newRows.push(row);
+      existingRows.delete(key);
+    });
 
-      const pricedInfo = getPricedInfo(item);
-      if (pricedInfo?.visible) {
-        nameDiv.classList.add('table-primary--with-mark');
-        const pricedMark = document.createElement('span');
-        pricedMark.className = 'priced-mark';
-        pricedMark.textContent = pricedInfo.priced ? '✅' : '❌';
-        pricedMark.title = pricedInfo.priced
-          ? 'Отмечен как «Посчитан»'
-          : 'Не отмечен как «Посчитан»';
-        nameDiv.appendChild(pricedMark);
-      }
+    existingRows.forEach(row => animateRowDeletion(row));
 
-      const nameText = document.createElement('span');
-      nameText.textContent = item.name || '';
-      nameDiv.appendChild(nameText);
-      nameTd.appendChild(nameDiv);
-      tr.appendChild(nameTd);
+    newRows.forEach(row => table.appendChild(row));
+    previousOrders = new Map(filtered.map(item => [getOrderKey(item), item]));
+  }
 
-      const managerTd = document.createElement('td');
-      const managerDiv = document.createElement('div');
-      managerDiv.className = 'table-secondary';
-      managerDiv.textContent = item.manager || '—';
-      managerTd.appendChild(managerDiv);
-      tr.appendChild(managerTd);
+  function hasOrderChanged(prev, next) {
+    return prev?.status !== next?.status
+      || prev?.manager !== next?.manager
+      || prev?.modified !== next?.modified
+      || prev?.name !== next?.name;
+  }
 
-      const statusTd = document.createElement('td');
-      const statusSpan = document.createElement('span');
-      statusSpan.className = statusClass;
-      statusSpan.textContent = item.status || '';
-      statusTd.appendChild(statusSpan);
-      tr.appendChild(statusTd);
+  function animateRowDeletion(row) {
+    if (!row) return;
+    const height = row.offsetHeight;
+    row.style.height = `${height}px`;
+    if (!PREFERS_REDUCED_MOTION) {
+      requestAnimationFrame(() => {
+        row.classList.add('is-deleting');
+        row.style.height = '0px';
+      });
+      setTimeout(() => row.remove(), 320);
+    } else {
+      row.remove();
+    }
+  }
 
-      const modifiedTd = document.createElement('td');
-      const modifiedDiv = document.createElement('div');
-      modifiedDiv.className = 'table-secondary';
-      modifiedDiv.textContent = item.modified || '';
-      modifiedTd.appendChild(modifiedDiv);
-      tr.appendChild(modifiedTd);
+  function fillOrderRow(tr, item, allowConfirmationUI) {
+    tr.innerHTML = '';
+    tr.className = '';
+    tr.dataset.orderKey = getOrderKey(item);
 
-      const daysTd = document.createElement('td');
-      const daysDiv = document.createElement('div');
-      daysDiv.className = 'table-secondary';
-      daysDiv.textContent = item.days ?? '—';
-      daysTd.appendChild(daysDiv);
-      tr.appendChild(daysTd);
+    if (item.status === 'Готов') {
+      tr.classList.add('done');
+    } else if (item.status === 'Подтвержден') {
+      tr.classList.add('confirmed');
+    } else {
+      tr.classList.add('new');
+    }
+
+    let statusClass = 'status-pill status-pill--warning';
+    if (item.status === 'Готов') {
+      statusClass = 'status-pill status-pill--success';
+    } else if (item.status === 'Подтвержден') {
+      statusClass = 'status-pill status-pill--neutral';
+    }
+
+    const nameTd = document.createElement('td');
+    const nameDiv = document.createElement('div');
+    nameDiv.className = 'table-primary';
+
+    const pricedInfo = getPricedInfo(item);
+    if (pricedInfo?.visible) {
+      nameDiv.classList.add('table-primary--with-mark');
+      const pricedMark = document.createElement('span');
+      pricedMark.className = 'priced-mark';
+      pricedMark.textContent = pricedInfo.priced ? '✅' : '❌';
+      pricedMark.title = pricedInfo.priced
+        ? 'Отмечен как «Посчитан»'
+        : 'Не отмечен как «Посчитан»';
+      nameDiv.appendChild(pricedMark);
+    }
+
+    const nameText = document.createElement('span');
+    nameText.textContent = item.name || '';
+    nameDiv.appendChild(nameText);
+    nameTd.appendChild(nameDiv);
+    tr.appendChild(nameTd);
+
+    const managerTd = document.createElement('td');
+    const managerDiv = document.createElement('div');
+    managerDiv.className = 'table-secondary';
+    managerDiv.textContent = item.manager || '—';
+    managerTd.appendChild(managerDiv);
+    tr.appendChild(managerTd);
+
+    const statusTd = document.createElement('td');
+    const statusSpan = document.createElement('span');
+    statusSpan.className = statusClass;
+    statusSpan.textContent = item.status || '';
+    statusTd.appendChild(statusSpan);
+    tr.appendChild(statusTd);
+
+    const modifiedTd = document.createElement('td');
+    const modifiedDiv = document.createElement('div');
+    modifiedDiv.className = 'table-secondary';
+    modifiedDiv.textContent = item.modified || '';
+    modifiedTd.appendChild(modifiedDiv);
+    tr.appendChild(modifiedTd);
+
+    const daysTd = document.createElement('td');
+    const daysDiv = document.createElement('div');
+    daysDiv.className = 'table-secondary';
+    daysDiv.textContent = item.days ?? '—';
+    daysTd.appendChild(daysDiv);
+    tr.appendChild(daysTd);
 
     if (allowConfirmationUI) {
       const confirmTd = document.createElement('td');
       confirmTd.className = 'table-checkbox';
 
-        if (item.status === 'Готов' && canConfirm(item)) {
-          const checkbox = document.createElement('input');
-          checkbox.type = 'checkbox';
-          checkbox.className = 'confirm-checkbox';
-          checkbox.checked = false;
-          const orderLabel = getOrderLabel(item);
-          const ariaLabel = orderLabel ? `Подтвердить заказ ${orderLabel}` : 'Подтвердить заказ';
-          checkbox.setAttribute('aria-label', ariaLabel);
-          checkbox.addEventListener('change', async () => {
-            await handleOrderConfirmation(item, checkbox);
-          });
-          confirmTd.appendChild(checkbox);
-        } else if (item.status === 'Подтвержден') {
-          const orderLabel = getOrderLabel(item);
-          const confirmedMark = document.createElement('span');
-          confirmedMark.className = 'confirm-status';
-          confirmedMark.textContent = '✔';
-          const ariaLabel = orderLabel ? `Заказ подтвержден ${orderLabel}` : 'Заказ подтвержден';
-          confirmedMark.setAttribute('aria-label', ariaLabel);
-          confirmedMark.title = orderLabel ? `Подтвержден: ${orderLabel}` : 'Заказ подтвержден';
-          confirmTd.appendChild(confirmedMark);
-        } else {
-          const placeholder = document.createElement('span');
-          placeholder.className = 'table-muted';
-          placeholder.textContent = '—';
-          confirmTd.appendChild(placeholder);
-        }
-
-        tr.appendChild(confirmTd);
+      if (item.status === 'Готов' && canConfirm(item)) {
+        const checkbox = document.createElement('input');
+        checkbox.type = 'checkbox';
+        checkbox.className = 'confirm-checkbox';
+        checkbox.checked = false;
+        const orderLabel = getOrderLabel(item);
+        const ariaLabel = orderLabel ? `Подтвердить заказ ${orderLabel}` : 'Подтвердить заказ';
+        checkbox.setAttribute('aria-label', ariaLabel);
+        checkbox.addEventListener('change', async () => {
+          await handleOrderConfirmation(item, checkbox);
+        });
+        confirmTd.appendChild(checkbox);
+      } else if (item.status === 'Подтвержден') {
+        const orderLabel = getOrderLabel(item);
+        const confirmedMark = document.createElement('span');
+        confirmedMark.className = 'status-pill status-pill--success';
+        confirmedMark.textContent = orderLabel ? `✓ ${orderLabel}` : 'Подтвержден';
+        confirmTd.appendChild(confirmedMark);
+      } else {
+        const placeholder = document.createElement('span');
+        placeholder.className = 'table-muted';
+        placeholder.textContent = '—';
+        confirmTd.appendChild(placeholder);
       }
 
-      table.appendChild(tr);
-    });
+      tr.appendChild(confirmTd);
+    }
   }
 
   function isReadyStatus(status) {
@@ -864,6 +956,11 @@ const OrdersPage = (() => {
     return extractOrderNumber(item.name);
   }
 
+  function getOrderKey(item) {
+    if (!item) return '';
+    return item.path || item.order_key || item.name || item.id || item.modified || Math.random().toString(16).slice(2);
+  }
+
   function extractOrderNumber(name) {
     if (!name) return '';
     const firstPart = name.trim().split(/\s+/)[0] || '';
@@ -1012,6 +1109,11 @@ const SettingsPage = (() => {
       setTimeout(() => feedback.classList.remove('is-visible'), 1500);
     } else {
       window.alert(message);
+    }
+
+    if (trigger) {
+      trigger.classList.add('flash-highlight');
+      setTimeout(() => trigger.classList.remove('flash-highlight'), 900);
     }
   }
 
@@ -1397,6 +1499,93 @@ const UsersTable = (() => {
 
     text.textContent = `Новый пароль для ${username}: ${password}`;
     box.classList.remove('is-hidden');
+  }
+
+  return { init };
+})();
+
+const UIEffects = (() => {
+  function init() {
+    renderToasts();
+    highlightJournal();
+    enhanceAuthForms();
+    rememberClients();
+  }
+
+  function renderToasts() {
+    const stack = document.getElementById('toastStack');
+    const page = document.body?.dataset?.page || '';
+    if (!stack || page !== 'settings') return;
+
+    const notices = document.querySelectorAll('.notice-card');
+    notices.forEach(notice => {
+      const text = notice.textContent.trim();
+      const type = notice.classList.contains('notice-card--error')
+        ? 'error'
+        : notice.classList.contains('notice-card--warning')
+          ? 'warning'
+          : 'success';
+      pushToast(stack, { title: type === 'error' ? 'Ошибка' : 'Состояние', desc: text, type });
+      notice.remove();
+    });
+  }
+
+  function pushToast(stack, { title, desc, type }) {
+    const toast = document.createElement('div');
+    toast.className = `toast toast--${type || 'info'}`;
+
+    toast.innerHTML = `
+      <div class="toast__title">${title || 'Сообщение'}</div>
+      <div class="toast__desc">${desc || ''}</div>
+      <button class="toast__close" aria-label="Закрыть">✕</button>
+    `;
+
+    toast.querySelector('.toast__close')?.addEventListener('click', () => toast.remove());
+    stack.appendChild(toast);
+    requestAnimationFrame(() => toast.classList.add('is-visible'));
+    setTimeout(() => toast.remove(), 4200);
+  }
+
+  function highlightJournal() {
+    if (!window.location.pathname.includes('journal')) return;
+    document.querySelectorAll('tbody tr').forEach((row, index) => {
+      if (index < 5) {
+        row.classList.add('flash-highlight');
+        setTimeout(() => row.classList.remove('flash-highlight'), 1100);
+      }
+    });
+  }
+
+  function enhanceAuthForms() {
+    const page = document.body?.dataset?.page || '';
+    if (page !== 'login' && page !== 'setup') return;
+    const hasError = document.querySelector('.notice-card--error');
+    if (!hasError) return;
+    document.querySelectorAll('input').forEach(input => {
+      input.classList.add('shake');
+      setTimeout(() => input.classList.remove('shake'), 320);
+    });
+  }
+
+  function rememberClients() {
+    if (!window.location.pathname.includes('clients')) return;
+    const addForm = document.querySelector('form[action="/add_client"]');
+    const nameInput = addForm?.querySelector('input[name="client"]');
+
+    addForm?.addEventListener('submit', () => {
+      if (nameInput?.value) {
+        sessionStorage.setItem('recentClientName', nameInput.value.trim());
+      }
+    });
+
+    const recentName = sessionStorage.getItem('recentClientName');
+    if (!recentName) return;
+    const row = document.querySelector(`tr[data-client="${CSS.escape(recentName)}"]`);
+    if (row) {
+      row.classList.add('flash-highlight');
+      setTimeout(() => row.classList.remove('flash-highlight'), 1200);
+      sessionStorage.removeItem('recentClientName');
+    }
   }
 
   return { init };
@@ -1836,6 +2025,7 @@ document.addEventListener('DOMContentLoaded', () => {
   FacadesPage.init();
   SettingsPage.init();
   UsersTable.init();
+  UIEffects.init();
 });
 
 const ClientsTable = (() => {
@@ -1879,6 +2069,10 @@ const ClientsTable = (() => {
     const oldName = row.dataset.client;
     const newName = row.querySelector('.edit-name').value.trim();
     const newManager = row.querySelector('.edit-manager').value.trim();
+
+    if (newName) {
+      sessionStorage.setItem('recentClientName', newName);
+    }
 
     fetch('/update_client', {
       method: 'POST',

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -16,6 +16,10 @@
   --border: rgba(148, 163, 184, 0.35);
   --text: #0f172a;
   --text-muted: #475569;
+  --easing: cubic-bezier(0.22, 0.61, 0.36, 1);
+  --dur-fast: 160ms;
+  --dur-medium: 280ms;
+  --dur-highlight: 900ms;
 }
 
 * {
@@ -28,6 +32,7 @@ body {
   font-family: inherit;
   background: linear-gradient(180deg, #eef2ff 0%, #f8fafc 100%);
   color: var(--text);
+  transition: background var(--dur-medium) ease;
 }
 
 .page {
@@ -57,7 +62,7 @@ body {
   padding: 9px 18px;
   border-radius: 999px;
   font-weight: 600;
-  transition: all 0.25s ease;
+  transition: transform var(--dur-fast) var(--easing), box-shadow var(--dur-fast) var(--easing), background var(--dur-fast) var(--easing);
 }
 
 .top-menu a:hover {
@@ -92,10 +97,17 @@ h1 {
   padding: 24px;
   box-shadow: 0 18px 32px -26px rgba(15, 23, 42, 0.4);
   border: 1px solid rgba(148, 163, 184, 0.25);
+  transition: transform var(--dur-medium) var(--easing), box-shadow var(--dur-medium) var(--easing), border-color var(--dur-medium) var(--easing);
 }
 
 .card + .card {
   margin-top: 24px;
+}
+
+.card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 22px 38px -28px rgba(15, 23, 42, 0.35);
+  border-color: rgba(37, 99, 235, 0.15);
 }
 
 .controls-card {
@@ -145,7 +157,7 @@ h1 {
   font-weight: 600;
   font-size: 0.95rem;
   cursor: pointer;
-  transition: transform 0.15s ease, box-shadow 0.2s ease, background 0.2s ease, border-color 0.2s ease;
+  transition: transform var(--dur-fast) var(--easing), box-shadow var(--dur-fast) var(--easing), background var(--dur-fast) var(--easing), border-color var(--dur-fast) var(--easing);
 }
 
 .btn:hover {
@@ -158,6 +170,11 @@ h1 {
   outline-offset: 2px;
 }
 
+.btn:active {
+  transform: translateY(1px);
+  box-shadow: 0 8px 18px -18px rgba(15, 23, 42, 0.45);
+}
+
 .btn--primary {
   background: var(--primary);
   color: #fff;
@@ -165,6 +182,11 @@ h1 {
 
 .btn--primary:hover {
   background: var(--primary-hover);
+}
+
+.btn--secondary {
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.08) 0%, rgba(16, 185, 129, 0.12) 100%);
+  color: var(--primary);
 }
 
 .btn--accent {
@@ -248,6 +270,17 @@ h1 {
   border-radius: 10px;
 }
 
+.btn--organic {
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.12) 0%, rgba(16, 185, 129, 0.16) 100%);
+  box-shadow: 0 16px 32px -24px rgba(37, 99, 235, 0.6);
+  border-color: rgba(37, 99, 235, 0.25);
+}
+
+.role-save {
+  min-width: 220px;
+  box-shadow: 0 18px 40px -30px rgba(37, 99, 235, 0.9);
+}
+
 .btn.is-active {
   background: rgba(37, 99, 235, 0.15);
   border-color: rgba(37, 99, 235, 0.4);
@@ -281,7 +314,7 @@ select {
   border: 1px solid rgba(148, 163, 184, 0.5);
   background: #fff;
   font-size: 1rem;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  transition: border-color var(--dur-fast) var(--easing), box-shadow var(--dur-fast) var(--easing), transform var(--dur-fast) var(--easing);
 }
 
 .input:focus,
@@ -293,6 +326,7 @@ select:focus {
   border-color: var(--primary);
   outline: none;
   box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.15);
+  transform: translateY(-1px);
 }
 
 .form-inline {
@@ -1580,6 +1614,15 @@ code {
 
 .checkbox-row input[type="checkbox"] {
   margin-top: 2px;
+  width: 18px;
+  height: 18px;
+  accent-color: var(--primary);
+  transition: transform var(--dur-fast) var(--easing), box-shadow var(--dur-fast) var(--easing);
+}
+
+.checkbox-row input[type="checkbox"]:checked {
+  transform: scale(1.05);
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.12);
 }
 
 .checkbox-row__content {
@@ -1729,6 +1772,54 @@ code {
   grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
 }
 
+.role-grid .role-card {
+  opacity: 0;
+  transform: translateY(8px);
+  animation: roleEnter var(--dur-medium) var(--easing) forwards;
+}
+
+.role-grid .role-card:nth-child(1) { animation-delay: 40ms; }
+.role-grid .role-card:nth-child(2) { animation-delay: 80ms; }
+.role-grid .role-card:nth-child(3) { animation-delay: 120ms; }
+.role-grid .role-card:nth-child(4) { animation-delay: 160ms; }
+.role-grid .role-card:nth-child(5) { animation-delay: 200ms; }
+
+.role-ready {
+  grid-column: 1 / -1;
+  padding: 18px;
+  border: 1px dashed rgba(37, 99, 235, 0.3);
+  border-radius: 14px;
+  background: rgba(37, 99, 235, 0.05);
+  display: grid;
+  gap: 10px;
+}
+
+.role-ready__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.role-ready__list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.role-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  border-radius: 999px;
+  background: #fff;
+  border: 1px solid rgba(37, 99, 235, 0.25);
+  box-shadow: 0 8px 22px -20px rgba(37, 99, 235, 0.6);
+  font-weight: 700;
+  color: var(--primary);
+}
+
 .manager-stats-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
@@ -1761,6 +1852,208 @@ code {
   margin: 0;
   color: var(--text-muted);
   font-size: 0.9rem;
+}
+
+/* Micro interactions */
+.is-entering {
+  opacity: 0;
+  transform: translateY(6px);
+}
+
+.is-entering.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+  transition: opacity var(--dur-medium) var(--easing), transform var(--dur-medium) var(--easing);
+}
+
+.is-updated,
+.flash-highlight {
+  animation: flashHighlight var(--dur-highlight) ease;
+}
+
+.is-deleting {
+  overflow: hidden;
+  opacity: 0;
+  margin-top: 0;
+  margin-bottom: 0;
+  padding-top: 0;
+  padding-bottom: 0;
+  transition: opacity var(--dur-medium) var(--easing), height var(--dur-medium) var(--easing), padding var(--dur-medium) var(--easing);
+}
+
+.shake {
+  animation: shakeField 0.28s ease;
+}
+
+@keyframes flashHighlight {
+  0% { background: rgba(37, 99, 235, 0.14); }
+  100% { background: transparent; }
+}
+
+@keyframes shakeField {
+  0%, 100% { transform: translateX(0); }
+  20% { transform: translateX(-4px); }
+  40% { transform: translateX(4px); }
+  60% { transform: translateX(-3px); }
+  80% { transform: translateX(3px); }
+}
+
+.table-card tbody tr {
+  transition: background var(--dur-fast) var(--easing), transform var(--dur-fast) var(--easing), box-shadow var(--dur-fast) var(--easing);
+}
+
+.table-card tbody tr:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 24px -20px rgba(15, 23, 42, 0.25);
+}
+
+.sse-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(148, 163, 184, 0.12);
+  font-weight: 600;
+  color: var(--text-muted);
+  width: fit-content;
+}
+
+.sse-status__dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--warning);
+  box-shadow: 0 0 0 0 rgba(16, 185, 129, 0.25);
+  transition: background var(--dur-fast) ease, box-shadow var(--dur-medium) ease;
+}
+
+.sse-status--ok {
+  border-color: rgba(16, 185, 129, 0.3);
+  background: rgba(16, 185, 129, 0.08);
+  color: var(--success);
+}
+
+.sse-status--ok .sse-status__dot {
+  background: var(--success);
+  animation: pulseStatus 2.4s ease infinite;
+}
+
+.sse-status--error {
+  border-color: rgba(220, 38, 38, 0.3);
+  background: rgba(220, 38, 38, 0.08);
+  color: var(--danger);
+}
+
+.sse-status--error .sse-status__dot {
+  background: var(--danger);
+  animation: none;
+}
+
+.sse-status--reconnect {
+  border-color: rgba(250, 204, 21, 0.3);
+  background: rgba(250, 204, 21, 0.1);
+  color: #92400e;
+}
+
+.toast-stack {
+  position: fixed;
+  top: 18px;
+  right: 18px;
+  display: grid;
+  gap: 10px;
+  z-index: 999;
+  pointer-events: none;
+}
+
+.toast {
+  min-width: 260px;
+  max-width: 340px;
+  padding: 12px 14px;
+  border-radius: 12px;
+  background: #fff;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  box-shadow: 0 16px 36px -28px rgba(15, 23, 42, 0.45);
+  display: grid;
+  gap: 4px;
+  transform: translateY(-6px);
+  opacity: 0;
+  pointer-events: auto;
+  transition: transform var(--dur-medium) var(--easing), opacity var(--dur-medium) var(--easing);
+}
+
+.toast.is-visible {
+  transform: translateY(0);
+  opacity: 1;
+}
+
+.toast__title {
+  font-weight: 700;
+  margin: 0;
+}
+
+.toast__desc {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.toast__close {
+  justify-self: end;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: var(--text-muted);
+}
+
+.toast--success { border-color: rgba(16, 185, 129, 0.35); }
+.toast--error { border-color: rgba(220, 38, 38, 0.35); }
+
+.copy-feedback.is-visible::before {
+  content: '✔';
+  margin-right: 6px;
+}
+
+.search-grow {
+  transition: transform var(--dur-medium) var(--easing), box-shadow var(--dur-medium) var(--easing), width var(--dur-medium) var(--easing);
+}
+
+.search-grow.is-focused {
+  transform: translateY(-1px) scale(1.04);
+  box-shadow: 0 12px 30px -24px rgba(37, 99, 235, 0.5);
+}
+
+@keyframes pulseStatus {
+  0% { box-shadow: 0 0 0 0 rgba(16, 185, 129, 0.35); }
+  70% { box-shadow: 0 0 0 10px rgba(16, 185, 129, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(16, 185, 129, 0); }
+}
+
+@keyframes roleEnter {
+  0% { opacity: 0; transform: translateY(10px); }
+  100% { opacity: 1; transform: translateY(0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+
+  .card:hover,
+  .table-card tbody tr:hover,
+  .btn:hover,
+  .btn:active,
+  .input:focus,
+  .select:focus,
+  textarea:focus {
+    transform: none;
+    box-shadow: none;
+  }
+
+  .sse-status__dot { animation: none !important; }
 }
 
 .manager-stat__empty {

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -60,6 +60,8 @@
       {% endif %}
     </nav>
 
+    <div class="toast-stack" id="toastStack" aria-live="polite" aria-atomic="true"></div>
+
     {% block content %}{% endblock %}
   </div>
 </body>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -11,6 +11,10 @@ data-order-confirmation="{{ 'true' if order_confirmation_enabled else 'false' }}
 {% block content %}
   <header class="page-header">
     <h1>📦 Мониторинг заказов</h1>
+    <div class="sse-status" id="sseStatus" aria-live="polite" aria-atomic="true">
+      <span class="sse-status__dot" aria-hidden="true"></span>
+      <span class="sse-status__text">Подключение…</span>
+    </div>
     <p class="page-description">
       Сводка по всем заказам в реальном времени. Используйте фильтры, чтобы быстро находить нужные проекты
       и контролировать их статус.
@@ -29,7 +33,7 @@ data-order-confirmation="{{ 'true' if order_confirmation_enabled else 'false' }}
       </div>
 	  <div class="filter-search">
           <label class="field-label" for="orderSearch">Поиск по названию</label>
-          <input type="search" id="orderSearch" class="input input--compact" placeholder="Начните ввод" autocomplete="off">
+          <input type="search" id="orderSearch" class="input input--compact search-grow" placeholder="Начните ввод" autocomplete="off">
         </div>
       <div class="controls-actions">
         <label class="field" for="managerSelect">

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -455,10 +455,22 @@ data-managers='{{ config_managers | tojson }}'
           </div>
           {% endfor %}
           <div class="role-card__footer">
-            <button type="submit" class="btn btn--secondary btn--pill">➕ Добавить роль</button>
+            <button type="submit" class="btn btn--secondary btn--pill btn--organic">➕ Добавить роль</button>
           </div>
         </form>
       </article>
+
+      <section class="role-ready" aria-label="Текущие роли">
+        <div class="role-ready__header">
+          <h3 class="section-title">Готовые роли</h3>
+          <p class="hint">Список существующих ролей отображается для быстрого выбора.</p>
+        </div>
+        <div class="role-ready__list">
+          {% for role, perms in role_permissions | dictsort %}
+            <span class="role-chip">{{ role_titles.get(role, role|capitalize) }}</span>
+          {% endfor %}
+        </div>
+      </section>
 
       <form action="{{ url_for('settings.update_role_permissions') }}" method="POST" class="role-editor role-cards-form" id="rolePermissionsForm">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
@@ -508,7 +520,7 @@ data-managers='{{ config_managers | tojson }}'
         </div>
 
         <div class="role-card__footer role-card__footer--sticky">
-          <button type="submit" class="btn btn--primary btn--pill">💾 Сохранить права</button>
+          <button type="submit" class="btn btn--primary btn--pill role-save">💾 Сохранить права</button>
         </div>
       </form>
     </div>


### PR DESCRIPTION
## Summary
- add subtle motion, hover, and focus effects with reduced-motion safeguards
- enhance orders page with live SSE status indicator, animated row updates, and smoother search
- polish settings roles layout with role badges, animated checkboxes, and toast notifications

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941cedc4b64832d92be122fe3a0f9a2)