### PR TITLE
Fix Telegram build stability and show order timing details

### DIFF
--- a/app/dal/db.py
+++ b/app/dal/db.py
@@ -209,6 +209,7 @@ def init_db() -> None:
     # Регистрируем все модели, зависящие от Base, перед созданием таблиц
     import app.dal.database  # noqa: F401
     import app.dal.external_orders  # noqa: F401
+    import app.dal.order_timeline  # noqa: F401
     import app.dal.manager_priced  # noqa: F401
 
     Base.metadata.create_all(engine)

--- a/app/dal/order_timeline.py
+++ b/app/dal/order_timeline.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import logging
+from typing import Dict, Iterable, Tuple
+
+from sqlalchemy import Column, Float, String
+
+from app.dal.db import Base, SessionLocal
+
+logger = logging.getLogger("bazis")
+
+
+class OrderTimeline(Base):
+    __tablename__ = "order_timelines"
+
+    order_key = Column(String, primary_key=True)
+    created_ts = Column(Float, nullable=True)
+    processed_ts = Column(Float, nullable=True)
+
+
+def load_timelines() -> Dict[str, Tuple[float | None, float | None]]:
+    """Возвращает все временные метки по заказам."""
+
+    with SessionLocal.begin() as session:
+        rows: Iterable[OrderTimeline] = session.query(OrderTimeline).all()
+        return {
+            row.order_key: (row.created_ts, row.processed_ts)
+            for row in rows
+            if row.order_key
+        }
+
+
+def upsert_created(order_key: str, created_ts: float) -> float | None:
+    """Сохраняет время создания, не затирая более ранние значения."""
+
+    if not order_key or created_ts is None:
+        return None
+
+    with SessionLocal.begin() as session:
+        record: OrderTimeline | None = session.get(OrderTimeline, order_key)
+        if record:
+            if record.created_ts is None or created_ts < record.created_ts:
+                record.created_ts = created_ts
+            return record.created_ts
+
+        session.add(OrderTimeline(order_key=order_key, created_ts=created_ts))
+        return created_ts
+
+
+def upsert_processed(order_key: str, processed_ts: float) -> float | None:
+    """Сохраняет время обработки технологом при первом появлении."""
+
+    if not order_key or processed_ts is None:
+        return None
+
+    with SessionLocal.begin() as session:
+        record: OrderTimeline | None = session.get(OrderTimeline, order_key)
+        if record:
+            if record.processed_ts is None:
+                record.processed_ts = processed_ts
+            return record.processed_ts
+
+        session.add(
+            OrderTimeline(
+                order_key=order_key,
+                processed_ts=processed_ts,
+            )
+        )
+        return processed_ts
+
+
+__all__ = [
+    "OrderTimeline",
+    "load_timelines",
+    "upsert_created",
+    "upsert_processed",
+]

--- a/app/services/monitor.py
+++ b/app/services/monitor.py
@@ -9,6 +9,7 @@ from watchdog.observers import Observer
 import app as bazis_app
 import app.config as app_config
 from app import heartbeat, measure_time
+from app.services import order_timeline
 from app.services import telegram as telegram_service
 from app.services.snapshot import remove_order, upsert_order
 
@@ -74,7 +75,14 @@ class OrderFolderHandler(FileSystemEventHandler):
         logger.info("[observer] Папка создана: %s", folder_name)
         if register_known_folder(folder_name):
             return
+        try:
+            created_ts = os.path.getctime(event.src_path)
+        except OSError:
+            created_ts = None
+        order_timeline.mark_created(folder_name, created_ts)
         upsert_order(folder_name)
+        if telegram_service.folder_has_ready_marker(folder_name):
+            order_timeline.mark_processed(folder_name)
         if telegram_service.should_notify(folder_name):
             telegram_service.enqueue(
                 telegram_service.send_telegram_message,
@@ -107,7 +115,10 @@ class OrderFolderHandler(FileSystemEventHandler):
         if dest_in_watch and not src_in_watch:
             if register_known_folder(dest_name):
                 return
+            order_timeline.mark_created(dest_name)
             upsert_order(dest_name)
+            if telegram_service.folder_has_ready_marker(dest_name):
+                order_timeline.mark_processed(dest_name)
             if telegram_service.should_notify(dest_name):
                 telegram_service.enqueue(
                     telegram_service.send_telegram_message,
@@ -125,6 +136,8 @@ class OrderFolderHandler(FileSystemEventHandler):
         logger.info("[observer] Папка переименована: %s -> %s", src_name, dest_name)
         remove_order(src_name)
         upsert_order(dest_name)
+        if telegram_service.folder_has_ready_marker(dest_name):
+            order_timeline.mark_processed(dest_name)
         telegram_service.enqueue(
             telegram_service.handle_moved_notification, src_name, dest_name, already_known
         )
@@ -299,6 +312,13 @@ def initialize_known_state():
                 name = entry.name
                 if telegram_service.is_folder_ignored(name):
                     continue
+                try:
+                    entry_stat = entry.stat()
+                    order_timeline.mark_created(name, entry_stat.st_ctime)
+                    if telegram_service.folder_has_ready_marker(name):
+                        order_timeline.mark_processed(name, entry_stat.st_mtime)
+                except OSError:
+                    pass
                 actual_folders.append(name)
     except Exception as exc:
         logger.exception("[init] Не удалось прочитать каталог", exc_info=exc)

--- a/app/services/order_timeline.py
+++ b/app/services/order_timeline.py
@@ -6,7 +6,15 @@ import time
 from datetime import datetime
 from typing import Dict, Optional
 
-from app.dal.order_timeline import load_timelines, upsert_created, upsert_processed
+from sqlalchemy.exc import IntegrityError
+
+from app.dal.order_timeline import (
+    OrderTimeline,
+    load_timelines,
+    upsert_created,
+    upsert_processed,
+)
+from app.dal.db import SessionLocal
 
 logger = logging.getLogger("bazis")
 _lock = threading.RLock()
@@ -79,13 +87,12 @@ def mark_created(order_name: str, created_ts: float | int | None = None) -> Opti
         if existing.get("created_ts") and existing["created_ts"] <= ts_val:
             return existing["created_ts"]
 
-    saved = upsert_created(key, ts_val)
-    with _lock:
+        saved = _upsert_created_safe(key, ts_val)
         entry = _timeline_cache.setdefault(key, {"created_ts": None, "processed_ts": None})
         if saved is not None:
             entry["created_ts"] = saved
         entry.setdefault("processed_ts", existing.get("processed_ts"))
-    return saved
+        return saved
 
 
 def mark_processed(order_name: str, processed_ts: float | int | None = None) -> Optional[float]:
@@ -101,13 +108,12 @@ def mark_processed(order_name: str, processed_ts: float | int | None = None) -> 
         if existing.get("processed_ts"):
             return existing["processed_ts"]
 
-    saved = upsert_processed(key, ts_val)
-    with _lock:
+        saved = _upsert_processed_safe(key, ts_val)
         entry = _timeline_cache.setdefault(key, {"created_ts": None, "processed_ts": None})
         if saved is not None:
             entry["processed_ts"] = saved
         entry.setdefault("created_ts", existing.get("created_ts"))
-    return saved
+        return saved
 
 
 def _calc_delta(created_ts: float | None, processed_ts: float | None) -> Optional[int]:
@@ -147,6 +153,48 @@ def enrich_entry(entry: dict, *, fallback_created: float | None = None, fallback
     entry["processing_seconds"] = _calc_delta(created_ts, processed_ts)
 
     return entry
+
+
+def _upsert_created_safe(order_key: str, ts_val: float) -> Optional[float]:
+    """Защита от гонок при одновременной вставке одинакового order_key."""
+
+    try:
+        return upsert_created(order_key, ts_val)
+    except IntegrityError:
+        logger.warning("[timeline] Повторная запись created для %s, читаем существующую", order_key)
+
+    with SessionLocal() as session:
+        record: OrderTimeline | None = session.get(OrderTimeline, order_key)
+        if record is None:
+            return None
+        if record.created_ts is None or ts_val < record.created_ts:
+            record.created_ts = ts_val
+            try:
+                session.commit()
+            except Exception:
+                session.rollback()
+        return record.created_ts
+
+
+def _upsert_processed_safe(order_key: str, ts_val: float) -> Optional[float]:
+    """Защита от гонок при записи processed."""
+
+    try:
+        return upsert_processed(order_key, ts_val)
+    except IntegrityError:
+        logger.warning("[timeline] Повторная запись processed для %s, читаем существующую", order_key)
+
+    with SessionLocal() as session:
+        record: OrderTimeline | None = session.get(OrderTimeline, order_key)
+        if record is None:
+            return None
+        if record.processed_ts is None:
+            record.processed_ts = ts_val
+            try:
+                session.commit()
+            except Exception:
+                session.rollback()
+        return record.processed_ts
 
 
 # Первичная загрузка кеша сразу после импорта модуля.

--- a/app/services/order_timeline.py
+++ b/app/services/order_timeline.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from datetime import datetime
+from typing import Dict, Optional
+
+from app.dal.order_timeline import load_timelines, upsert_created, upsert_processed
+
+logger = logging.getLogger("bazis")
+_lock = threading.RLock()
+_timeline_cache: Dict[str, Dict[str, float | None]] = {}
+
+
+def _order_key_from_name(name: str | None) -> str:
+    if not name:
+        return ""
+    return (name.split()[0] or "").lower()
+
+
+def _normalize_ts(value: float | int | None) -> float | None:
+    if value is None:
+        return None
+    try:
+        ts_val = float(value)
+        return ts_val if ts_val > 0 else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _format_ts(ts: float | None) -> str:
+    if ts is None:
+        return ""
+    try:
+        return datetime.fromtimestamp(ts).strftime("%d.%m.%Y %H:%M")
+    except Exception:
+        return ""
+
+
+def load_cache() -> None:
+    """Полностью перечитывает кеш из БД."""
+
+    with _lock:
+        _timeline_cache.clear()
+        try:
+            source = load_timelines()
+        except Exception as exc:
+            logger.warning("[timeline] Не удалось загрузить кеш временных меток", exc_info=exc)
+            return
+
+        for key, (created_ts, processed_ts) in source.items():
+            _timeline_cache[key] = {
+                "created_ts": _normalize_ts(created_ts),
+                "processed_ts": _normalize_ts(processed_ts),
+            }
+
+
+def get_timeline(order_name: str | None) -> Dict[str, float | None]:
+    key = _order_key_from_name(order_name)
+    with _lock:
+        stored = _timeline_cache.get(key, {}).copy()
+    stored.setdefault("created_ts", None)
+    stored.setdefault("processed_ts", None)
+    stored["order_key"] = key
+    return stored
+
+
+def mark_created(order_name: str, created_ts: float | int | None = None) -> Optional[float]:
+    """Фиксирует время создания, не затирая более ранние значения."""
+
+    key = _order_key_from_name(order_name)
+    ts_val = _normalize_ts(created_ts) or time.time()
+    if not key:
+        return None
+
+    with _lock:
+        existing = _timeline_cache.get(key, {})
+        if existing.get("created_ts") and existing["created_ts"] <= ts_val:
+            return existing["created_ts"]
+
+    saved = upsert_created(key, ts_val)
+    with _lock:
+        entry = _timeline_cache.setdefault(key, {"created_ts": None, "processed_ts": None})
+        if saved is not None:
+            entry["created_ts"] = saved
+        entry.setdefault("processed_ts", existing.get("processed_ts"))
+    return saved
+
+
+def mark_processed(order_name: str, processed_ts: float | int | None = None) -> Optional[float]:
+    """Фиксирует время обработки технологом при первом появлении маркера."""
+
+    key = _order_key_from_name(order_name)
+    ts_val = _normalize_ts(processed_ts) or time.time()
+    if not key:
+        return None
+
+    with _lock:
+        existing = _timeline_cache.get(key, {})
+        if existing.get("processed_ts"):
+            return existing["processed_ts"]
+
+    saved = upsert_processed(key, ts_val)
+    with _lock:
+        entry = _timeline_cache.setdefault(key, {"created_ts": None, "processed_ts": None})
+        if saved is not None:
+            entry["processed_ts"] = saved
+        entry.setdefault("created_ts", existing.get("created_ts"))
+    return saved
+
+
+def _calc_delta(created_ts: float | None, processed_ts: float | None) -> Optional[int]:
+    if created_ts is None or processed_ts is None:
+        return None
+    return max(0, int(processed_ts - created_ts))
+
+
+def enrich_entry(entry: dict, *, fallback_created: float | None = None, fallback_processed: float | None = None) -> dict:
+    """Заполняет временные поля заказа и при необходимости сохраняет их в БД."""
+
+    if not isinstance(entry, dict):
+        return entry
+
+    name = entry.get("name") or ""
+    key = entry.get("order_key") or _order_key_from_name(name)
+    created_ts = _normalize_ts(entry.get("created_ts")) or _normalize_ts(fallback_created)
+    processed_ts = _normalize_ts(entry.get("processed_ts")) or _normalize_ts(fallback_processed)
+
+    current = get_timeline(name)
+
+    if current.get("created_ts") is None and created_ts is not None:
+        created_ts = mark_created(name, created_ts) or created_ts
+    else:
+        created_ts = current.get("created_ts") or created_ts
+
+    if current.get("processed_ts") is None and processed_ts is not None:
+        processed_ts = mark_processed(name, processed_ts) or processed_ts
+    else:
+        processed_ts = current.get("processed_ts") or processed_ts
+
+    entry["order_key"] = key
+    entry["created_ts"] = created_ts
+    entry["processed_ts"] = processed_ts
+    entry["created"] = _format_ts(created_ts) if created_ts else ""
+    entry["processed"] = _format_ts(processed_ts) if processed_ts else ""
+    entry["processing_seconds"] = _calc_delta(created_ts, processed_ts)
+
+    return entry
+
+
+# Первичная загрузка кеша сразу после импорта модуля.
+load_cache()
+
+__all__ = [
+    "enrich_entry",
+    "get_timeline",
+    "load_cache",
+    "mark_created",
+    "mark_processed",
+]

--- a/app/services/snapshot.py
+++ b/app/services/snapshot.py
@@ -19,6 +19,7 @@ from app.services.audit import log_order_event
 from app.dal.db import DB_PATH
 from app.services import telegram as telegram_service
 from app.services.telegram import folder_has_ready_marker, technologist_from_folder
+from app.services import order_timeline
 
 MONTHS_RO = {
     1: "01. Ianuarie",
@@ -72,14 +73,19 @@ def calculate_period_cutoff(months_back: int) -> float:
 
 
 def parse_folder_entry(
-    folder_name: str, stat_mtime: Optional[float] = None, now_ts: Optional[float] = None
+    folder_name: str,
+    stat_mtime: Optional[float] = None,
+    now_ts: Optional[float] = None,
+    stat_result=None,
 ):
     if telegram_service.is_folder_ignored(folder_name):
         return None
 
     folder_path = os.path.join(app_config.FOLDER_PATH or "", folder_name)
     try:
-        mtime_ts = stat_mtime if stat_mtime is not None else os.path.getmtime(folder_path)
+        stat = stat_result or os.stat(folder_path)
+        mtime_ts = stat_mtime if stat_mtime is not None else stat.st_mtime
+        created_ts = getattr(stat, "st_ctime", None)
     except OSError:
         return None
 
@@ -92,8 +98,9 @@ def parse_folder_entry(
     order_number = extract_order_number_from_folder(folder_name) or ""
 
     days_ago = int((now_ts - mtime_ts) // 86400)
+    processed_ts = mtime_ts if folder_has_ready_marker(folder_name) else None
 
-    return {
+    entry = {
         "name": folder_name,
         "status": status,
         "manager": manager,
@@ -103,7 +110,12 @@ def parse_folder_entry(
         "days": days_ago,
         "confirmed": confirmed,
         "order_number": order_number,
-}
+        "order_key": order_number.lower(),
+        "created_ts": created_ts,
+        "processed_ts": processed_ts,
+    }
+
+    return order_timeline.enrich_entry(entry, fallback_created=created_ts, fallback_processed=processed_ts)
 
 INDEX_TTL = 300.0
 _index_lock = threading.Lock()
@@ -163,8 +175,13 @@ def build_orders_snapshot():
             for entry in it:
                 if not entry.is_dir():
                     continue
-
-                parsed = parse_folder_entry(entry.name, stat_mtime=entry.stat().st_mtime, now_ts=now_ts)
+                entry_stat = entry.stat()
+                parsed = parse_folder_entry(
+                    entry.name,
+                    stat_mtime=entry_stat.st_mtime,
+                    now_ts=now_ts,
+                    stat_result=entry_stat,
+                )
                 if parsed:
                     folder_data.append(parsed)
     except FileNotFoundError:

--- a/app/services/telegram.py
+++ b/app/services/telegram.py
@@ -1,9 +1,11 @@
 import json
+import os
 import queue
 import threading
 from typing import List, Optional
 
 from telegram import Bot
+from telegram.utils.request import Request
 
 import app as bazis_app
 import app.config as app_config
@@ -16,6 +18,7 @@ messages: List[dict] = []
 messages_lock = threading.Lock()
 tg_queue: "queue.Queue[tuple]" = queue.Queue(maxsize=1000)
 _disabled_warning_logged = False
+_cert_patched = False
 
 
 def _telegram_configured() -> bool:
@@ -63,12 +66,41 @@ def start_worker_once():
         threading.Thread(target=_worker, daemon=True).start()
         _worker_started = True
 
+
+def _ensure_cert_bundle() -> None:
+    """Гарантирует, что в frozen-сборках есть путь к цепочке сертификации."""
+
+    global _cert_patched
+    if _cert_patched:
+        return
+    if "SSL_CERT_FILE" in os.environ:
+        _cert_patched = True
+        return
+    try:
+        import certifi
+
+        cert_path = certifi.where()
+        if cert_path and os.path.exists(cert_path):
+            os.environ.setdefault("SSL_CERT_FILE", cert_path)
+            logger.info("[TG] SSL_CERT_FILE установлен для Telegram запросов.")
+    except Exception:
+        logger.warning("[TG] Не удалось установить SSL_CERT_FILE для Telegram", exc_info=True)
+    finally:
+        _cert_patched = True
+
+
 def init_bot(token: str) -> None:
     global bot, _disabled_warning_logged
     _disabled_warning_logged = False
     if token and app_config.CHAT_ID:
-        bot = Bot(token=token)
-        start_worker_once()
+        try:
+            _ensure_cert_bundle()
+            request = Request(con_pool_size=8, read_timeout=20, connect_timeout=20)
+            bot = Bot(token=token, request=request)
+            start_worker_once()
+        except Exception as exc:
+            bot = None
+            logger.exception("[TG] Не удалось инициализировать бота", exc_info=exc)
     else:
         bot = None
 

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -124,6 +124,22 @@ const OrdersPage = (() => {
   let previousOrders = new Map();
   let sseStatus = { root: null, dot: null, text: null };
 
+  function formatDuration(seconds) {
+    if (seconds === null || seconds === undefined) return '';
+    const total = Math.max(0, Math.floor(seconds));
+    const days = Math.floor(total / 86400);
+    const hours = Math.floor((total % 86400) / 3600);
+    const minutes = Math.floor((total % 3600) / 60);
+
+    const parts = [];
+    if (days) parts.push(`${days} д`);
+    if (hours) parts.push(`${hours} ч`);
+    if (!days && minutes) parts.push(`${minutes} м`);
+    if (!days && !hours && !minutes) parts.push('<1 м');
+
+    return parts.slice(0, 2).join(' ');
+  }
+
   function init() {
     const table = document.getElementById('orders');
     if (!table) return;
@@ -463,7 +479,9 @@ const OrdersPage = (() => {
       || prev?.name !== next?.name
       || prev?.display_name !== next?.display_name
       || prev?.is_approved !== next?.is_approved
-      || prev?.is_cancelled !== next?.is_cancelled;
+      || prev?.is_cancelled !== next?.is_cancelled
+      || prev?.created !== next?.created
+      || prev?.processed !== next?.processed;
   }
 
   function animateRowDeletion(row) {
@@ -523,6 +541,31 @@ const OrdersPage = (() => {
     const nameText = document.createElement('span');
     nameText.textContent = item.display_name || item.name || '';
     nameDiv.appendChild(nameText);
+
+    const metaDiv = document.createElement('div');
+    metaDiv.className = 'order-meta';
+
+    if (item.created) {
+      const createdLine = document.createElement('div');
+      createdLine.className = 'order-meta__item';
+      createdLine.textContent = `Создано: ${item.created}`;
+      metaDiv.appendChild(createdLine);
+    }
+
+    if (item.processed) {
+      const processedLine = document.createElement('div');
+      processedLine.className = 'order-meta__item';
+      const durationText = formatDuration(item.processing_seconds);
+      processedLine.textContent = durationText
+        ? `Обработан: ${item.processed} · ${durationText}`
+        : `Обработан: ${item.processed}`;
+      metaDiv.appendChild(processedLine);
+    }
+
+    if (metaDiv.children.length) {
+      nameDiv.appendChild(metaDiv);
+    }
+
     nameTd.appendChild(nameDiv);
     tr.appendChild(nameTd);
 

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -720,6 +720,22 @@ select:focus {
   gap: 8px;
 }
 
+.order-meta {
+  margin-top: 4px;
+  display: grid;
+  gap: 2px;
+  color: #6b7280;
+  font-size: 0.82rem;
+  line-height: 1.2;
+}
+
+.order-meta__item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  white-space: nowrap;
+}
+
 .priced-mark {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- ensure the Telegram bot initializes reliably in frozen builds by pinning the cert bundle and logging initialization failures
- track order creation and technologist processing timestamps in a dedicated timeline store and include them in snapshots
- render creation/processing times and elapsed duration under each order name with compact styling

## Testing
- python -m compileall app

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695122a63840832da85366ada0edae21)