### PR TITLE
Persist order timestamps and harden telegram in build

### DIFF
--- a/app/dal/db.py
+++ b/app/dal/db.py
@@ -210,6 +210,7 @@ def init_db() -> None:
     import app.dal.database  # noqa: F401
     import app.dal.external_orders  # noqa: F401
     import app.dal.manager_priced  # noqa: F401
+    import app.dal.order_timestamps  # noqa: F401
 
     Base.metadata.create_all(engine)
     _ensure_role_permissions_columns()

--- a/app/dal/order_timestamps.py
+++ b/app/dal/order_timestamps.py
@@ -1,0 +1,25 @@
+from datetime import datetime, timezone
+
+from sqlalchemy import Column, DateTime, String
+
+from app.dal.db import Base
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class OrderTimestamp(Base):
+    __tablename__ = "order_timestamps"
+
+    # stable_key — инвариантный ключ заказа (номер или имя без служебных префиксов)
+    stable_key = Column(String, primary_key=True)
+    order_name = Column(String, nullable=False)
+    created_at = Column(DateTime(timezone=True))
+    processed_at = Column(DateTime(timezone=True))
+    created_source = Column(String)
+    processed_source = Column(String)
+    last_seen_at = Column(DateTime(timezone=True), default=_utcnow)
+
+
+__all__ = ["OrderTimestamp"]

--- a/app/services/order_timestamps.py
+++ b/app/services/order_timestamps.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import logging
+import os
+import re
+from datetime import datetime, timezone
+from typing import Dict, Iterable, List, Optional
+
+import app.config as app_config
+from app.dal.db import SessionLocal
+from app.dal.order_timestamps import OrderTimestamp
+from app.services.order_numbers import extract_order_number_from_folder, normalize_plus_suffix
+
+logger = logging.getLogger("bazis")
+
+READY_MARKER_RE = re.compile(r"^\s*\[\$\]\s*", re.IGNORECASE)
+ANULAT_RE = re.compile(r"\[\s*anulat\s*\]", re.IGNORECASE)
+
+
+def _utc_from_ts(ts: float | None) -> Optional[datetime]:
+    if ts is None:
+        return None
+    try:
+        return datetime.fromtimestamp(float(ts), tz=timezone.utc)
+    except Exception:
+        return None
+
+
+def _now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _clean_name(name: str) -> str:
+    # убираем служебные маркеры и лишние пробелы
+    cleaned = READY_MARKER_RE.sub("", name or "")
+    cleaned = ANULAT_RE.sub("", cleaned)
+    cleaned = normalize_plus_suffix(cleaned)
+    cleaned = re.sub(r"\s+", " ", cleaned).strip()
+    return cleaned
+
+
+def build_stable_key(order_name: str) -> str:
+    """Инвариантный ключ: номер заказа, иначе имя без служебных меток."""
+
+    order_number = extract_order_number_from_folder(order_name) or ""
+    if order_number:
+        return order_number.lower()
+    return _clean_name(order_name).lower()
+
+
+def _load_existing(stable_keys: Iterable[str]) -> Dict[str, OrderTimestamp]:
+    keys = list({k for k in stable_keys if k})
+    if not keys:
+        return {}
+    with SessionLocal.begin() as session:
+        rows = (
+            session.query(OrderTimestamp)
+            .filter(OrderTimestamp.stable_key.in_(keys))
+            .all()
+        )
+        return {row.stable_key: row for row in rows}
+
+
+def ensure_records(
+    entries: List[dict],
+    source: str,
+) -> Dict[str, OrderTimestamp]:
+    """
+    Гарантирует наличие записей created/processed для переданных заказов.
+    Возвращает карту stable_key -> запись (после фиксации).
+    """
+
+    stable_keys = [build_stable_key(entry.get("name", "")) for entry in entries]
+    existing = _load_existing(stable_keys)
+
+    to_update: List[OrderTimestamp] = []
+    now = _now_utc()
+
+    for entry, stable_key in zip(entries, stable_keys):
+        entry["stable_key"] = stable_key
+        name = entry.get("name") or stable_key
+        created_candidate = _utc_from_ts(entry.get("ctime_ts")) or _utc_from_ts(entry.get("mtime_ts"))
+        processed_candidate = _utc_from_ts(entry.get("mtime_ts")) or now
+        is_processed = entry.get("status") in {"Готов", "Подтвержден"} or entry.get("has_technologist")
+
+        record = existing.get(stable_key)
+        if not record:
+            record = OrderTimestamp(
+                stable_key=stable_key,
+                order_name=name,
+                created_at=created_candidate,
+                processed_at=processed_candidate if is_processed else None,
+                created_source=source if created_candidate else None,
+                processed_source=source if is_processed else None,
+                last_seen_at=now,
+            )
+            existing[stable_key] = record
+            to_update.append(record)
+            logger.info(
+                "[order_ts] created_at зафиксирован %s (%s) source=%s ctime=%s mtime=%s",
+                stable_key,
+                name,
+                source,
+                created_candidate,
+                entry.get("mtime_ts"),
+            )
+            if is_processed:
+                logger.info(
+                    "[order_ts] processed_at зафиксирован сразу при первом обнаружении %s source=%s ts=%s",
+                    stable_key,
+                    source,
+                    processed_candidate,
+                )
+        else:
+            # обновляем динамические поля без перезаписи времён
+            if record.order_name != name:
+                record.order_name = name
+            record.last_seen_at = now
+            if record.created_at is None and created_candidate:
+                record.created_at = created_candidate
+                record.created_source = record.created_source or source
+                logger.info(
+                    "[order_ts] created_at заполнен задним числом %s source=%s ts=%s",
+                    stable_key,
+                    source,
+                    created_candidate,
+                )
+            if is_processed and record.processed_at is None:
+                record.processed_at = processed_candidate
+                record.processed_source = source
+                logger.info(
+                    "[order_ts] processed_at зафиксирован %s source=%s ts=%s",
+                    stable_key,
+                    source,
+                    processed_candidate,
+                )
+            to_update.append(record)
+
+    if to_update:
+        with SessionLocal.begin() as session:
+            for record in to_update:
+                session.merge(record)
+    return existing
+
+
+def format_elapsed(created: Optional[datetime], processed: Optional[datetime]) -> str | None:
+    if not created or not processed:
+        return None
+    delta = processed - created
+    total_seconds = int(delta.total_seconds())
+    if total_seconds < 0:
+        logger.warning(
+            "[order_ts] Вычислена отрицательная дельта processed-created: %s секунд (c=%s, p=%s)",
+            total_seconds,
+            created,
+            processed,
+        )
+        return "—"
+    minutes, seconds = divmod(total_seconds, 60)
+    hours, minutes = divmod(minutes, 60)
+    if hours:
+        return f"{hours}ч {minutes}м"
+    if minutes:
+        return f"{minutes}м {seconds}с"
+    return f"{seconds}с"
+
+
+def stat_ctime(path: str) -> Optional[float]:
+    try:
+        return os.path.getctime(path)
+    except OSError:
+        return None
+
+
+__all__ = ["build_stable_key", "ensure_records", "format_elapsed", "stat_ctime"]

--- a/app/services/snapshot.py
+++ b/app/services/snapshot.py
@@ -14,6 +14,7 @@ import app as bazis_app
 import app.config as app_config
 from app import get_manager_from_name, heartbeat, logger, measure_time, sse_broadcast
 from app.services import order_status
+from app.services import order_timestamps
 from app.services.order_numbers import extract_order_number_from_folder
 from app.services.audit import log_order_event
 from app.dal.db import DB_PATH
@@ -43,6 +44,38 @@ def _format_modified(ts_value: float) -> str:
         return datetime.fromtimestamp(ts_value).strftime("%d.%m.%Y %H:%M")
     except Exception:
         return ""
+
+
+def _format_dt_local(dt: datetime | None) -> str:
+    if not dt:
+        return ""
+    try:
+        return dt.astimezone(CHISINAU_TZ).strftime("%d.%m.%Y %H:%M")
+    except Exception:
+        return ""
+
+
+def _attach_timestamps(entries: List[Dict], source: str) -> List[Dict]:
+    if not entries:
+        return entries
+
+    records = order_timestamps.ensure_records(entries, source=source)
+
+    for entry in entries:
+        record = records.get(entry.get("stable_key"))
+        if not record:
+            continue
+
+        created = record.created_at
+        processed = record.processed_at
+
+        entry["created_at"] = created.isoformat() if created else None
+        entry["processed_at"] = processed.isoformat() if processed else None
+        entry["created_at_display"] = _format_dt_local(created) if created else ""
+        entry["processed_at_display"] = _format_dt_local(processed) if processed else ""
+        entry["elapsed_display"] = order_timestamps.format_elapsed(created, processed)
+
+    return entries
 
 
 def _shift_months(dt: datetime, months_back: int) -> datetime:
@@ -79,7 +112,9 @@ def parse_folder_entry(
 
     folder_path = os.path.join(app_config.FOLDER_PATH or "", folder_name)
     try:
-        mtime_ts = stat_mtime if stat_mtime is not None else os.path.getmtime(folder_path)
+        stat = os.stat(folder_path)
+        mtime_ts = stat_mtime if stat_mtime is not None else stat.st_mtime
+        ctime_ts = getattr(stat, "st_ctime", None)
     except OSError:
         return None
 
@@ -99,6 +134,7 @@ def parse_folder_entry(
         "manager": manager,
         "technologist": technologist,
         "mtime_ts": mtime_ts,
+        "ctime_ts": ctime_ts,
         "modified": "",
         "days": days_ago,
         "confirmed": confirmed,
@@ -172,8 +208,13 @@ def build_orders_snapshot():
 
     try:
         folder_data = order_status.enrich_orders(folder_data)
+        folder_data = _attach_timestamps(folder_data, source="snapshot_scan")
     except Exception as exc:  # pragma: no cover - защитная логика
         logger.warning("[snapshot] enrich_orders failed, fallback to raw data", exc_info=exc)
+        try:
+            folder_data = _attach_timestamps(folder_data, source="snapshot_scan_fallback")
+        except Exception:
+            logger.warning("[snapshot] attach_timestamps fallback failed", exc_info=True)
 
     dt = (perf_counter() - t0) * 1000.0
     with bazis_app.metrics_lock:
@@ -268,6 +309,7 @@ def upsert_order(folder_name: str) -> bool:
         return remove_order(folder_name)
 
     parsed = order_status.enrich_orders([parsed])[0]
+    parsed = _attach_timestamps([parsed], source="watchdog")[0]
     changed, applied_snapshot, version, last_snapshot_ts, existed = _merge_order(parsed)
     if changed:
         payload = build_orders_payload(

--- a/app/services/telegram.py
+++ b/app/services/telegram.py
@@ -1,25 +1,66 @@
 import json
+import os
 import queue
+import sys
 import threading
 from typing import List, Optional
 
+import certifi
 from telegram import Bot
+from telegram.utils.request import Request
 
 import app as bazis_app
 import app.config as app_config
 from app import get_manager_from_name, logger
 from app.dal.database import load_messages as load_messages_from_db
 from app.dal.database import replace_messages as replace_messages_in_db
+from app.paths import get_base_dir
 
 bot: Optional[Bot] = None
 messages: List[dict] = []
 messages_lock = threading.Lock()
 tg_queue: "queue.Queue[tuple]" = queue.Queue(maxsize=1000)
 _disabled_warning_logged = False
+_config_state_logged = False
+
+
+def _runtime_mode() -> str:
+    return "frozen" if getattr(sys, "frozen", False) else "source"
+
+
+def _mask(value: str | None) -> str:
+    if not value:
+        return ""
+    if len(value) <= 8:
+        return "***"
+    return f"{value[:4]}***{value[-4:]}"
+
+
+def _log_config_state() -> None:
+    global _config_state_logged
+    if _config_state_logged:
+        return
+    _config_state_logged = True
+
+    base_dir = get_base_dir()
+    config_path = os.path.join(base_dir, "config.json")
+    env_path = os.path.join(base_dir, ".env")
+    logger.info(
+        "[TG] runtime=%s base_dir=%s config=%s env=%s token=%s chat_id=%s",
+        _runtime_mode(),
+        base_dir,
+        config_path,
+        env_path,
+        _mask(app_config.TELEGRAM_TOKEN),
+        app_config.CHAT_ID or "(empty)",
+    )
 
 
 def _telegram_configured() -> bool:
-    return bot is not None and bool(app_config.CHAT_ID)
+    configured = bot is not None and bool(app_config.CHAT_ID)
+    if not configured:
+        _log_config_state()
+    return configured
 
 
 def _log_disabled_once() -> None:
@@ -27,7 +68,11 @@ def _log_disabled_once() -> None:
     if _disabled_warning_logged:
         return
     _disabled_warning_logged = True
-    logger.warning("[TG] Бот не настроен: пропускаем задачи отправки.")
+    logger.warning(
+        "[TG] Бот не настроен: пропускаем задачи отправки (token=%s, chat_id=%s)",
+        _mask(app_config.TELEGRAM_TOKEN),
+        app_config.CHAT_ID or "(empty)",
+    )
 
 
 def enqueue(fn, *args, **kwargs) -> None:
@@ -66,11 +111,31 @@ def start_worker_once():
 def init_bot(token: str) -> None:
     global bot, _disabled_warning_logged
     _disabled_warning_logged = False
+    _log_config_state()
+
     if token and app_config.CHAT_ID:
-        bot = Bot(token=token)
+        request = Request(
+            con_pool_size=8,
+            read_timeout=20,
+            connect_timeout=20,
+            request_kwargs={"verify": certifi.where()},
+        )
+        bot = Bot(token=token, request=request)
         start_worker_once()
+        logger.info(
+            "[TG] Бот инициализирован (mode=%s, token=%s, chat_id=%s, ca=%s)",
+            _runtime_mode(),
+            _mask(token),
+            app_config.CHAT_ID,
+            certifi.where(),
+        )
     else:
         bot = None
+        logger.warning(
+            "[TG] Бот не инициализирован (token=%s, chat_id=%s)",
+            _mask(token),
+            app_config.CHAT_ID or "(empty)",
+        )
 
 
 def load_messages_storage() -> None:
@@ -159,6 +224,7 @@ def send_telegram_message(msg: str, folder_name: str) -> None:
         _log_disabled_once()
         return
     try:
+        logger.info("[TG] Отправка сообщения для %s", folder_name)
         sent = bot.send_message(chat_id=app_config.CHAT_ID, text=msg)
         entry = {
             "folder": folder_name,
@@ -176,7 +242,12 @@ def send_telegram_message(msg: str, folder_name: str) -> None:
             sent.message_id,
         )
     except Exception as exc:
-        logger.exception("[Telegram Error] %s", exc)
+        logger.exception(
+            "[Telegram Error] Ошибка отправки сообщения (folder=%s, chat_id=%s)",
+            folder_name,
+            app_config.CHAT_ID,
+            exc_info=exc,
+        )
 
 
 def delete_telegram_message(folder_name: str) -> None:

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -463,7 +463,10 @@ const OrdersPage = (() => {
       || prev?.name !== next?.name
       || prev?.display_name !== next?.display_name
       || prev?.is_approved !== next?.is_approved
-      || prev?.is_cancelled !== next?.is_cancelled;
+      || prev?.is_cancelled !== next?.is_cancelled
+      || prev?.created_at_display !== next?.created_at_display
+      || prev?.processed_at_display !== next?.processed_at_display
+      || prev?.elapsed_display !== next?.elapsed_display;
   }
 
   function animateRowDeletion(row) {
@@ -523,6 +526,13 @@ const OrdersPage = (() => {
     const nameText = document.createElement('span');
     nameText.textContent = item.display_name || item.name || '';
     nameDiv.appendChild(nameText);
+    const meta = buildMetaLine(item);
+    if (meta) {
+      const metaSpan = document.createElement('div');
+      metaSpan.className = 'order-meta';
+      metaSpan.textContent = meta;
+      nameDiv.appendChild(metaSpan);
+    }
     nameTd.appendChild(nameDiv);
     tr.appendChild(nameTd);
 
@@ -563,9 +573,23 @@ const OrdersPage = (() => {
     return null;
   }
 
+  function buildMetaLine(item) {
+    const parts = [];
+    if (item?.created_at_display) {
+      parts.push(`Создан: ${item.created_at_display}`);
+    }
+    if (item?.processed_at_display) {
+      parts.push(`Обработан: ${item.processed_at_display}`);
+      if (item?.elapsed_display) {
+        parts.push(`Прошло: ${item.elapsed_display}`);
+      }
+    }
+    return parts.join(' • ');
+  }
+
   function getOrderKey(item) {
     if (!item) return '';
-    return item.path || item.order_key || item.name || item.id || item.modified || Math.random().toString(16).slice(2);
+    return item.path || item.order_key || item.stable_key || item.name || item.id || item.modified || Math.random().toString(16).slice(2);
   }
 
   return {

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -720,6 +720,14 @@ select:focus {
   gap: 8px;
 }
 
+.order-meta {
+  display: block;
+  margin-top: 4px;
+  color: var(--text-muted);
+  font-size: 0.82rem;
+  line-height: 1.1;
+}
+
 .priced-mark {
   display: inline-flex;
   align-items: center;

--- a/build/build_windows.py
+++ b/build/build_windows.py
@@ -37,6 +37,10 @@ def build() -> int:
         _fmt_data_arg(base_dir / "app" / "static", "app/static"),
         _fmt_data_arg(base_dir / "app" / "templates", "app/templates"),
     ]
+    for optional in ("config.json", ".env"):
+        candidate = base_dir / optional
+        if candidate.exists():
+            data_args.append(_fmt_data_arg(candidate, optional))
 
     pyinstaller_args = [
         "--noconfirm",
@@ -47,6 +51,7 @@ def build() -> int:
         f"--distpath={dist_dir}",
         f"--workpath={work_dir}",
         f"--specpath={work_dir}",
+        "--collect-all=certifi",
         #f"--key={cipher_key}",
     ]
     for data_arg in data_args:
@@ -59,7 +64,7 @@ def build() -> int:
     target_dir.mkdir(parents=True, exist_ok=True)
 
     # Копируем пользовательские файлы рядом с exe, оставляя их в открытом доступе.
-    for filename in ("config.json", "database.db"):
+    for filename in ("config.json", "database.db", ".env"):
         src = base_dir / filename
         if src.exists():
             shutil.copy2(src, target_dir / filename)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ python-telegram-bot
 SQLAlchemy
 psycopg2-binary
 pytest
+certifi


### PR DESCRIPTION
## Summary
- add SQLite order_timestamps model and service to keep created/processed times stable across renames and expose formatted fields in SSE/UI
- render created/processed/elapsed info in the orders table and keep rows stable via a new stable key
- improve Telegram initialization/logging for frozen builds, enable certifi bundle, and document PyInstaller data/collect options

## Testing
- python -m compileall app

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951414007e8832da765547e95de1be8)