### PR TITLE
Add backend DESENE CPU monitoring with role-aware API and persistence

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -167,12 +167,14 @@ def register_blueprints(flask_app: Flask):
     from app.routes.clients import clients_bp
     from app.routes.orders import orders_bp
     from app.routes.settings import settings_bp
+    from app.routes.cpu import cpu_bp
 
     flask_app.register_blueprint(setup_bp)
     flask_app.register_blueprint(auth_bp)
     flask_app.register_blueprint(orders_bp)
     flask_app.register_blueprint(clients_bp)
     flask_app.register_blueprint(settings_bp)
+    flask_app.register_blueprint(cpu_bp)
 
 
 def _attach_logger(flask_app: Flask) -> None:
@@ -209,6 +211,7 @@ def start_background_services():
     from app.services import orders_sync
     from app.services import snapshot as snapshot_service
     from app.services import telegram as telegram_service
+    from app.services import cpu_monitor
 
     telegram_service.init_bot(app_config.TELEGRAM_TOKEN)
     telegram_service.load_messages_storage()
@@ -220,6 +223,7 @@ def start_background_services():
     monitor_service.start_observer_once()
     orders_sync.start_sync_worker()
     orders_auto_confirm.start_auto_confirm_worker()
+    cpu_monitor.start_cpu_monitor_worker()
 
     services_started = True
 

--- a/app/config.py
+++ b/app/config.py
@@ -31,7 +31,7 @@ DEFAULT_CONFIG = {
     "managers": [],
     "technologists": {},
     "search": {"months": 6},
-    "features": {"order_confirmation": False},
+    "features": {"order_confirmation": False, "cpu_monitoring_enabled": False},
     "retention": {"logs_days": 30, "journal_days": 90},
     "orders_times": {"ttl_days": 30},
     "orders_sync": {
@@ -275,6 +275,10 @@ def _ensure_complete_config(raw_config: dict) -> dict:
     merged.setdefault("features", {})
     merged["features"]["order_confirmation"] = _parse_bool(
         merged["features"].get("order_confirmation"), DEFAULT_CONFIG["features"]["order_confirmation"]
+    )
+    merged["features"]["cpu_monitoring_enabled"] = _parse_bool(
+        merged["features"].get("cpu_monitoring_enabled"),
+        DEFAULT_CONFIG["features"]["cpu_monitoring_enabled"],
     )
 
     merged.setdefault("retention", {})

--- a/app/dal/cpu_orders.py
+++ b/app/dal/cpu_orders.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import Boolean, Column, DateTime, String, Text, func, or_
+
+from app.dal.db import Base, SessionLocal
+
+
+class CpuOrder(Base):
+    __tablename__ = "cpu_orders"
+
+    order_key = Column(String, primary_key=True)
+    folder_name = Column(String, nullable=False)
+    full_path = Column(Text, nullable=False)
+    year_month_path = Column(String, nullable=True)
+
+    pdf_visible = Column(Boolean, nullable=False, default=False)
+    pdf_type_found = Column(String, nullable=True)
+    pdf_filename = Column(String, nullable=True)
+
+    manager_name = Column(String, nullable=True)
+    status_cpu = Column(String, nullable=False, default="ready")
+
+    sent_at = Column(DateTime(timezone=True), nullable=True)
+    confirmed_at = Column(DateTime(timezone=True), nullable=True)
+    missing_path = Column(Boolean, nullable=False, default=False)
+
+    created_at = Column(DateTime(timezone=True), server_default=func.current_timestamp())
+    updated_at = Column(
+        DateTime(timezone=True),
+        server_default=func.current_timestamp(),
+        onupdate=func.current_timestamp(),
+    )
+
+
+def get_cpu_order(order_key: str) -> Optional[CpuOrder]:
+    with SessionLocal.begin() as session:
+        return session.get(CpuOrder, order_key)
+
+
+def list_cpu_ready_orders() -> list[CpuOrder]:
+    with SessionLocal.begin() as session:
+        return (
+            session.query(CpuOrder)
+            .filter(
+                CpuOrder.pdf_visible.is_(True),
+                CpuOrder.status_cpu == "ready",
+                CpuOrder.missing_path.is_(False),
+            )
+            .order_by(CpuOrder.updated_at.desc(), CpuOrder.created_at.desc())
+            .all()
+        )
+
+
+def list_cpu_archive_orders(query: str = "", status: str = "", manager: str = "") -> list[CpuOrder]:
+    normalized_query = (query or "").strip().lower()
+    normalized_status = (status or "").strip().lower()
+    normalized_manager = (manager or "").strip()
+
+    with SessionLocal.begin() as session:
+        db_query = session.query(CpuOrder).filter(CpuOrder.status_cpu.in_(("review", "confirmed")))
+
+        if normalized_status in {"review", "confirmed"}:
+            db_query = db_query.filter(CpuOrder.status_cpu == normalized_status)
+
+        if normalized_manager:
+            db_query = db_query.filter(CpuOrder.manager_name == normalized_manager)
+
+        if normalized_query:
+            like_expr = f"%{normalized_query}%"
+            db_query = db_query.filter(
+                or_(
+                    func.lower(CpuOrder.folder_name).like(like_expr),
+                    func.lower(CpuOrder.manager_name).like(like_expr),
+                    func.lower(CpuOrder.pdf_filename).like(like_expr),
+                )
+            )
+
+        return db_query.order_by(CpuOrder.updated_at.desc(), CpuOrder.created_at.desc()).all()
+
+
+def upsert_cpu_order(
+    *,
+    order_key: str,
+    folder_name: str,
+    full_path: str,
+    year_month_path: str,
+    pdf_visible: bool,
+    pdf_type_found: str,
+    pdf_filename: str,
+    manager_name: str,
+    status_cpu: str = "ready",
+    missing_path: bool = False,
+) -> CpuOrder:
+    now = datetime.utcnow()
+    with SessionLocal.begin() as session:
+        record = session.get(CpuOrder, order_key)
+        if not record:
+            record = CpuOrder(order_key=order_key, created_at=now)
+            session.add(record)
+
+        record.folder_name = folder_name
+        record.full_path = full_path
+        record.year_month_path = year_month_path
+        record.pdf_visible = bool(pdf_visible)
+        record.pdf_type_found = pdf_type_found or None
+        record.pdf_filename = pdf_filename or None
+        record.manager_name = manager_name or "Неизвестно"
+        record.missing_path = bool(missing_path)
+
+        # Убираем из active, если PDF пропал, но архивные не трогаем.
+        if record.status_cpu == "ready" and not record.pdf_visible:
+            record.status_cpu = "ready"
+        elif record.status_cpu not in {"ready", "review", "confirmed"}:
+            record.status_cpu = status_cpu
+
+        record.updated_at = now
+        return record
+
+
+def mark_cpu_order_missing(order_keys: set[str]) -> None:
+    if not order_keys:
+        return
+
+    now = datetime.utcnow()
+    with SessionLocal.begin() as session:
+        rows = session.query(CpuOrder).filter(CpuOrder.order_key.in_(list(order_keys))).all()
+        for row in rows:
+            row.missing_path = True
+            row.pdf_visible = False
+            row.pdf_type_found = None
+            row.pdf_filename = None
+            row.updated_at = now
+
+
+def update_cpu_status(order_key: str, status_cpu: str) -> Optional[CpuOrder]:
+    now = datetime.utcnow()
+    with SessionLocal.begin() as session:
+        row = session.get(CpuOrder, order_key)
+        if not row:
+            return None
+
+        row.status_cpu = status_cpu
+        if status_cpu == "review":
+            row.sent_at = row.sent_at or now
+        if status_cpu == "confirmed":
+            row.confirmed_at = now
+        row.updated_at = now
+        return row
+
+
+def update_cpu_manager(order_key: str, manager_name: str) -> Optional[CpuOrder]:
+    now = datetime.utcnow()
+    with SessionLocal.begin() as session:
+        row = session.get(CpuOrder, order_key)
+        if not row:
+            return None
+        row.manager_name = manager_name
+        row.updated_at = now
+        return row
+
+
+__all__ = [
+    "CpuOrder",
+    "get_cpu_order",
+    "list_cpu_ready_orders",
+    "list_cpu_archive_orders",
+    "upsert_cpu_order",
+    "mark_cpu_order_missing",
+    "update_cpu_status",
+    "update_cpu_manager",
+]

--- a/app/dal/db.py
+++ b/app/dal/db.py
@@ -230,6 +230,7 @@ def init_db() -> None:
     import app.dal.external_orders  # noqa: F401
     import app.dal.manager_priced  # noqa: F401
     import app.dal.order_manager_override  # noqa: F401
+    import app.dal.cpu_orders  # noqa: F401
 
     Base.metadata.create_all(engine)
     _ensure_role_permissions_columns()

--- a/app/routes/cpu.py
+++ b/app/routes/cpu.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from flask import Blueprint, abort, jsonify, request, session
+
+import app.config as app_config
+from app.dal.cpu_orders import (
+    get_cpu_order,
+    list_cpu_archive_orders,
+    list_cpu_ready_orders,
+    update_cpu_manager,
+    update_cpu_status,
+)
+from app.dal.order_manager_override import upsert_override
+from app.services.cpu_monitor import sync_cpu_orders
+
+cpu_bp = Blueprint("cpu", __name__)
+
+
+def _normalize_role() -> str:
+    return (session.get("role") or "").strip().lower()
+
+
+def _is_manager_of_order(order_manager: str) -> bool:
+    username = (session.get("user") or "").strip().lower()
+    manager_name = (order_manager or "").strip().lower()
+    return bool(username and manager_name and username == manager_name)
+
+
+def _can_view_order(order: dict) -> bool:
+    role = _normalize_role()
+    if role in {"admin", "technologist"}:
+        return True
+    if role == "manager":
+        return _is_manager_of_order(order.get("manager_name") or order.get("manager"))
+    return False
+
+
+def _require_action_permission(order) -> None:
+    role = _normalize_role()
+    if role in {"admin", "technologist"}:
+        return
+    if role == "manager" and _is_manager_of_order(order.manager_name):
+        return
+    abort(403)
+
+
+def _serialize(row) -> dict:
+    return {
+        "order_key": row.order_key,
+        "folder_name": row.folder_name,
+        "full_path": row.full_path,
+        "year_month_path": row.year_month_path or "",
+        "pdf_visible": bool(row.pdf_visible),
+        "pdf_type_found": row.pdf_type_found or "",
+        "pdf_filename": row.pdf_filename or "",
+        "manager_name": row.manager_name or "Неизвестно",
+        "status_cpu": row.status_cpu,
+        "sent_at": row.sent_at.isoformat() if row.sent_at else "",
+        "confirmed_at": row.confirmed_at.isoformat() if row.confirmed_at else "",
+        "updated_at": row.updated_at.isoformat() if row.updated_at else "",
+        "missing_path": bool(row.missing_path),
+    }
+
+
+@cpu_bp.route("/api/cpu/orders", methods=["GET"])
+def cpu_orders():
+    if not app_config.CONFIG.get("features", {}).get("cpu_monitoring_enabled", False):
+        return jsonify({"status": "ok", "orders": []})
+
+    sync_cpu_orders()
+    rows = list_cpu_ready_orders()
+    visible = [_serialize(row) for row in rows if _can_view_order(_serialize(row))]
+    return jsonify({"status": "ok", "orders": visible})
+
+
+@cpu_bp.route("/api/cpu/archive", methods=["GET"])
+def cpu_archive():
+    query = request.args.get("query", "")
+    status = request.args.get("status", "")
+    manager = request.args.get("manager", "")
+
+    sync_cpu_orders()
+    rows = list_cpu_archive_orders(query=query, status=status, manager=manager)
+    visible = [_serialize(row) for row in rows if _can_view_order(_serialize(row))]
+    return jsonify({"status": "ok", "orders": visible})
+
+
+@cpu_bp.route("/api/cpu/order/<order_key>/send", methods=["POST"])
+def cpu_send(order_key: str):
+    order = get_cpu_order(order_key)
+    if not order:
+        return jsonify({"status": "error", "message": "Заказ не найден."}), 404
+
+    _require_action_permission(order)
+    update_cpu_status(order_key, "review")
+
+    refreshed = get_cpu_order(order_key)
+    return jsonify({"status": "ok", "full_path": refreshed.full_path if refreshed else order.full_path})
+
+
+@cpu_bp.route("/api/cpu/order/<order_key>/confirm", methods=["POST"])
+def cpu_confirm(order_key: str):
+    order = get_cpu_order(order_key)
+    if not order:
+        return jsonify({"status": "error", "message": "Заказ не найден."}), 404
+
+    _require_action_permission(order)
+    update_cpu_status(order_key, "confirmed")
+    return jsonify({"status": "ok"})
+
+
+@cpu_bp.route("/api/cpu/order/<order_key>/assign-manager", methods=["POST"])
+def cpu_assign_manager(order_key: str):
+    order = get_cpu_order(order_key)
+    if not order:
+        return jsonify({"status": "error", "message": "Заказ не найден."}), 404
+
+    _require_action_permission(order)
+    payload = request.get_json(silent=True) or {}
+    manager_name = (
+        payload.get("manager_name")
+        or payload.get("manager_id")
+        or payload.get("manager")
+        or ""
+    ).strip()
+
+    if manager_name not in app_config.MANAGER_NAMES:
+        return jsonify({"status": "error", "message": "Менеджер не найден."}), 400
+
+    updated_by = session.get("user") or ""
+    upsert_override(order_key, manager_name, updated_by)
+    update_cpu_manager(order_key, manager_name)
+    return jsonify({"status": "ok"})
+
+
+__all__ = ["cpu_bp"]

--- a/app/routes/settings.py
+++ b/app/routes/settings.py
@@ -146,6 +146,7 @@ def settings_page():
             pg_enabled = request.form.get("orders_sync_enabled") == "on"
             plus_rename = request.form.get("orders_plus_rename") == "on"
             anulat_rename = request.form.get("orders_anulat_rename") == "on"
+            cpu_monitoring_enabled = request.form.get("cpu_monitoring_enabled") == "on"
             not_given_folder = request.form.get("not_given_folder_path", "").strip()
 
             telegram_token = request.form.get("telegram_token", "").strip()
@@ -207,6 +208,9 @@ def settings_page():
             orders_sync_cfg["enabled"] = pg_enabled
             orders_sync_cfg["approved_plus_rename"] = plus_rename
             orders_sync_cfg["anulat_rename_tech_marker"] = anulat_rename
+
+            features_cfg = updated.setdefault("features", {})
+            features_cfg["cpu_monitoring_enabled"] = cpu_monitoring_enabled
 
             if not not_given_folder:
                 errors.append("Путь к папке «НЕ ДАЛИ В РАБОТУ» не может быть пустым.")

--- a/app/services/cpu_monitor.py
+++ b/app/services/cpu_monitor.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import hashlib
+import os
+import threading
+import time
+from dataclasses import dataclass
+
+import app.config as app_config
+from app import get_manager_from_name, logger
+from app.dal.cpu_orders import mark_cpu_order_missing, upsert_cpu_order
+from app.dal.order_manager_override import get_overrides_map
+
+_SCAN_INTERVAL_SECONDS = 45
+_worker_started = False
+_worker_lock = threading.Lock()
+
+
+@dataclass
+class CpuPdfMatch:
+    visible: bool
+    pdf_type: str
+    pdf_filename: str
+
+
+def build_cpu_order_key(full_path: str) -> str:
+    normalized = os.path.normcase(os.path.abspath(full_path))
+    digest = hashlib.sha1(normalized.encode("utf-8", errors="ignore")).hexdigest()
+    return f"cpu:{digest}"
+
+
+def _is_year_folder(name: str) -> bool:
+    return name.isdigit() and len(name) == 4
+
+
+def _find_pdf_match(order_folder_path: str, folder_name: str) -> CpuPdfMatch:
+    try:
+        files = [entry.name for entry in os.scandir(order_folder_path) if entry.is_file()]
+    except OSError:
+        return CpuPdfMatch(visible=False, pdf_type="", pdf_filename="")
+
+    files_map = {file_name.lower(): file_name for file_name in files}
+
+    if "cpu.pdf" in files_map:
+        name = files_map["cpu.pdf"]
+        return CpuPdfMatch(visible=True, pdf_type="CPU.pdf", pdf_filename=name)
+
+    order_pdf = f"{folder_name}.pdf"
+    lowered_order_pdf = order_pdf.lower()
+    if lowered_order_pdf in files_map:
+        name = files_map[lowered_order_pdf]
+        return CpuPdfMatch(visible=True, pdf_type="folder.pdf", pdf_filename=name)
+
+    if " " in folder_name:
+        order_number = folder_name.split(" ", 1)[0].strip()
+        if order_number:
+            num_pdf = f"{order_number}.pdf".lower()
+            if num_pdf in files_map:
+                name = files_map[num_pdf]
+                return CpuPdfMatch(visible=True, pdf_type="order.pdf", pdf_filename=name)
+
+    return CpuPdfMatch(visible=False, pdf_type="", pdf_filename="")
+
+
+def _iter_order_folders(root_path: str):
+    for year in sorted(os.listdir(root_path)):
+        year_path = os.path.join(root_path, year)
+        if not os.path.isdir(year_path) or not _is_year_folder(year):
+            continue
+
+        for month_name in sorted(os.listdir(year_path)):
+            month_path = os.path.join(year_path, month_name)
+            if not os.path.isdir(month_path):
+                continue
+
+            year_month_path = os.path.join(year, month_name)
+            for order_name in os.listdir(month_path):
+                order_path = os.path.join(month_path, order_name)
+                if not os.path.isdir(order_path):
+                    continue
+                yield order_name, order_path, year_month_path
+
+
+def sync_cpu_orders() -> dict[str, int]:
+    root_path = app_config.DESENE_CPU_ROOT
+    if not app_config.CONFIG.get("features", {}).get("cpu_monitoring_enabled", False):
+        return {"processed": 0, "visible": 0, "missing": 0}
+
+    if not root_path or not os.path.isdir(root_path):
+        return {"processed": 0, "visible": 0, "missing": 0}
+
+    processed = 0
+    visible = 0
+    seen_keys: set[str] = set()
+
+    batch: list[dict] = []
+    for folder_name, full_path, year_month_path in _iter_order_folders(root_path):
+        order_key = build_cpu_order_key(full_path)
+        seen_keys.add(order_key)
+
+        pdf_match = _find_pdf_match(full_path, folder_name)
+        manager_name = get_manager_from_name(folder_name)
+
+        batch.append(
+            {
+                "order_key": order_key,
+                "folder_name": folder_name,
+                "full_path": full_path,
+                "year_month_path": year_month_path,
+                "pdf_visible": pdf_match.visible,
+                "pdf_type_found": pdf_match.pdf_type,
+                "pdf_filename": pdf_match.pdf_filename,
+                "manager_name": manager_name,
+            }
+        )
+
+    overrides = get_overrides_map([item["order_key"] for item in batch])
+
+    for item in batch:
+        record = overrides.get(item["order_key"])
+        if record:
+            item["manager_name"] = record.manager_name
+
+        upsert_cpu_order(**item)
+        processed += 1
+        if item["pdf_visible"]:
+            visible += 1
+
+    from app.dal.cpu_orders import CpuOrder
+    from app.dal.db import SessionLocal
+
+    with SessionLocal.begin() as session:
+        existing = {row[0] for row in session.query(CpuOrder.order_key).all()}
+
+    missing = existing - seen_keys
+    mark_cpu_order_missing(missing)
+
+    return {"processed": processed, "visible": visible, "missing": len(missing)}
+
+
+def start_cpu_monitor_worker() -> None:
+    global _worker_started
+    with _worker_lock:
+        if _worker_started:
+            return
+        _worker_started = True
+
+    def _worker() -> None:
+        while True:
+            try:
+                result = sync_cpu_orders()
+                logger.debug("[cpu-monitor] sync result: %s", result)
+            except Exception:
+                logger.exception("[cpu-monitor] sync failed")
+            time.sleep(_SCAN_INTERVAL_SECONDS)
+
+    thread = threading.Thread(target=_worker, daemon=True, name="cpu-monitor-worker")
+    thread.start()
+
+
+__all__ = [
+    "build_cpu_order_key",
+    "sync_cpu_orders",
+    "start_cpu_monitor_worker",
+]

--- a/tests/test_cpu_monitoring.py
+++ b/tests/test_cpu_monitoring.py
@@ -1,0 +1,138 @@
+import os
+from pathlib import Path
+
+import pytest
+
+import app.config as app_config
+from app import create_app
+from app.dal.cpu_orders import CpuOrder, get_cpu_order
+from app.dal.db import SessionLocal
+from app.services.cpu_monitor import build_cpu_order_key, sync_cpu_orders
+
+
+@pytest.fixture
+def cpu_root(tmp_path: Path):
+    root = tmp_path / "DESENE CPU"
+    folder = root / "2026" / "02. Februarie 2026" / "666-02 CLIENT [$]"
+    folder.mkdir(parents=True)
+    return root, folder
+
+
+@pytest.fixture
+def client_with_role(cpu_root):
+    root, _ = cpu_root
+    app_config.CONFIG.setdefault("features", {})["cpu_monitoring_enabled"] = True
+    app_config.DESENE_CPU_ROOT = str(root)
+
+    os.environ["BAZIS_DISABLE_BACKGROUND"] = "1"
+    app = create_app()
+    app.config.update(TESTING=True)
+
+    with app.test_client() as client:
+        yield client
+
+
+def _set_session(client, role: str, username: str):
+    with client.session_transaction() as sess:
+        sess["user"] = username
+        sess["role"] = role
+        sess["csrf_token"] = "test-csrf"
+
+
+def _headers():
+    return {"X-CSRF-Token": "test-csrf"}
+
+
+def _clean_cpu_table():
+    with SessionLocal.begin() as session:
+        session.query(CpuOrder).delete()
+
+
+def test_folder_without_pdf_not_in_active_orders(client_with_role, cpu_root):
+    client = client_with_role
+    _clean_cpu_table()
+
+    _set_session(client, "technologist", "tech")
+    response = client.get("/api/cpu/orders")
+
+    assert response.status_code == 200
+    assert response.get_json()["orders"] == []
+
+
+def test_cpu_pdf_appears_in_active_orders(client_with_role, cpu_root):
+    client = client_with_role
+    _, folder = cpu_root
+    _clean_cpu_table()
+
+    (folder / "CPU.pdf").write_text("pdf")
+    _set_session(client, "technologist", "tech")
+
+    response = client.get("/api/cpu/orders")
+    payload = response.get_json()
+
+    assert response.status_code == 200
+    assert len(payload["orders"]) == 1
+    assert payload["orders"][0]["pdf_filename"].lower() == "cpu.pdf"
+    assert payload["orders"][0]["status_cpu"] == "ready"
+
+
+def test_send_and_confirm_status_flow(client_with_role, cpu_root):
+    client = client_with_role
+    _, folder = cpu_root
+    _clean_cpu_table()
+
+    (folder / "CPU.pdf").write_text("pdf")
+    sync_cpu_orders()
+    order_key = build_cpu_order_key(str(folder))
+
+    _set_session(client, "technologist", "tech")
+
+    send_resp = client.post(f"/api/cpu/order/{order_key}/send", headers=_headers())
+    assert send_resp.status_code == 200
+    assert get_cpu_order(order_key).status_cpu == "review"
+
+    confirm_resp = client.post(f"/api/cpu/order/{order_key}/confirm", headers=_headers())
+    assert confirm_resp.status_code == 200
+    refreshed = get_cpu_order(order_key)
+    assert refreshed.status_cpu == "confirmed"
+    assert refreshed.confirmed_at is not None
+
+
+def test_manager_cannot_change_foreign_order(client_with_role, cpu_root):
+    client = client_with_role
+    _, folder = cpu_root
+    _clean_cpu_table()
+
+    (folder / "CPU.pdf").write_text("pdf")
+    sync_cpu_orders()
+    order_key = build_cpu_order_key(str(folder))
+
+    # Тестовый менеджер не совпадает с manager_name заказа.
+    _set_session(client, "manager", "another_manager")
+    response = client.post(f"/api/cpu/order/{order_key}/send", headers=_headers())
+
+    assert response.status_code == 403
+
+
+def test_technologist_can_change_any_order_and_archive_filters(client_with_role, cpu_root):
+    client = client_with_role
+    _, folder = cpu_root
+    _clean_cpu_table()
+
+    (folder / "CPU.pdf").write_text("pdf")
+    sync_cpu_orders()
+    order_key = build_cpu_order_key(str(folder))
+
+    _set_session(client, "technologist", "tech")
+    send_resp = client.post(f"/api/cpu/order/{order_key}/send", headers=_headers())
+    assert send_resp.status_code == 200
+
+    archive_resp = client.get("/api/cpu/archive")
+    assert archive_resp.status_code == 200
+    orders = archive_resp.get_json()["orders"]
+    assert len(orders) == 1
+    assert orders[0]["status_cpu"] == "review"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
### Motivation
- Добавить отдельный backend-модуль для мониторинга DESENE CPU, не трогая существующий основной мониторинг и UI, согласно требованиям (PDF-gated видимость, статусный workflow, привязка менеджера). 
- Переиспользовать существующую архитектуру (DAL/Services/Blueprint/DB/config/settings) и механизм ручного назначения менеджера.
- Обеспечить серверную проверку прав (manager/technologist/admin) и сохранение состояния в БД, включая архивирование без удаления записей при пропаже папки.

### Description
- Добавлена модель и DAL `CpuOrder` в `app/dal/cpu_orders.py` для хранения `order_key`, `folder_name`, `full_path`, `year_month_path`, `pdf_visible`, `pdf_type_found`, `pdf_filename`, `manager_name`, `status_cpu`, `sent_at`, `confirmed_at`, `missing_path`, `created_at`, `updated_at` и CRUD/фильтрующие хелперы (`get_cpu_order`, `upsert_cpu_order`, `list_cpu_ready_orders`, `list_cpu_archive_orders`, `update_cpu_status`, `update_cpu_manager`, `mark_cpu_order_missing`).
- Реализован сервис сканирования `app/services/cpu_monitor.py`, который обходит структуру `DESENE CPU/YYYY/MM/...`, применяет правило видимости по PDF (`CPU.pdf`, `{folder}.pdf`, `{order_number}.pdf`), рассчитывает устойчивый `order_key` (SHA1 от абсолютного пути), учитывает существующие overrides менеджера и обновляет БД, помечая пропавшие папки через `missing_path` без удаления архивных записей.
- Добавлен blueprint и API в `app/routes/cpu.py` с энпойнтами: `GET /api/cpu/orders`, `GET /api/cpu/archive`, `POST /api/cpu/order/<order_key>/send`, `POST /api/cpu/order/<order_key>/confirm`, `POST /api/cpu/order/<order_key>/assign-manager`, включая серверную проверку прав: менеджер — только для своих заказов, технолог — для всех, admin — всё; при отсутствии прав возвращается `403`.
- Интеграция в приложение: регистрация blueprint и запуск фонового worker в `app/__init__.py`, регистрация модели в `init_db()` через `app/dal/db.py`, расширение настроек в `app/config.py` (`features.cpu_monitoring_enabled`), а также сохранение флага через существующий settings flow в `app/routes/settings.py`.
- Тесты: добавлен набор тестов `tests/test_cpu_monitoring.py` проверяющий основные кейсы (исключение папки без PDF, появление при `CPU.pdf`, `send->review`, `confirm->confirmed`, права менеджера/технолога). Все изменения выполнены локально без модификации UI/шаблонов.

### Testing
- Запущены автоматические тесты `PYTHONPATH=. pytest -q tests/test_cpu_monitoring.py`, результат: `5 passed` (все сценарии CPU monitoring покрыты и прошли успешно).
- Тесты охватывают: отсутствие PDF исключает заказ из `GET /api/cpu/orders`, появление `CPU.pdf` делает заказ видимым, `POST /send` переводит в `review`, `POST /confirm` переводит в `confirmed`, менеджер получает `403` для чужого заказа, технолог может обрабатывать все заказы и `GET /api/cpu/archive` возвращает записи со статусами `review`/`confirmed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a096a4d3e8832da9d4e936e9e2f756)