### PR TITLE
Add DESENE CPU monitoring UI (pages, settings, JS, CSS)

### DIFF
--- a/app/routes/cpu.py
+++ b/app/routes/cpu.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from flask import Blueprint, abort, jsonify, request, session
+from flask import Blueprint, abort, jsonify, render_template, request, session
 
 import app.config as app_config
 from app.dal.cpu_orders import (
@@ -14,6 +14,16 @@ from app.dal.order_manager_override import upsert_override
 from app.services.cpu_monitor import sync_cpu_orders
 
 cpu_bp = Blueprint("cpu", __name__)
+
+
+@cpu_bp.route("/cpu", methods=["GET"])
+def cpu_page():
+    return render_template("cpu.html", cpu_view="active")
+
+
+@cpu_bp.route("/cpu/archive", methods=["GET"])
+def cpu_archive_page():
+    return render_template("cpu.html", cpu_view="archive")
 
 
 def _normalize_role() -> str:

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -1997,3 +1997,332 @@ const ClientsTable = (() => {
 document.addEventListener('DOMContentLoaded', () => {
   ClientsTable.init();
 });
+
+const CpuPage = (() => {
+  let activeOrders = [];
+  let archiveOrders = [];
+  let query = '';
+  let manager = '';
+  let status = '';
+  let searchTimer = null;
+
+  function init() {
+    if (document.body?.dataset?.page !== 'cpu') return;
+
+    const searchInput = document.getElementById('cpuArchiveSearch');
+    const managerSelect = document.getElementById('cpuArchiveManager');
+    const statusSelect = document.getElementById('cpuArchiveStatus');
+
+    searchInput?.addEventListener('input', () => {
+      if (searchTimer) clearTimeout(searchTimer);
+      searchTimer = setTimeout(() => {
+        query = (searchInput.value || '').trim();
+        loadArchive();
+      }, 180);
+    });
+
+    managerSelect?.addEventListener('change', () => {
+      manager = managerSelect.value || '';
+      loadArchive();
+    });
+
+    statusSelect?.addEventListener('change', () => {
+      status = statusSelect.value || '';
+      loadArchive();
+    });
+
+    bindActions();
+
+    if (getView() === 'archive') {
+      loadArchive();
+    } else {
+      loadActive();
+    }
+  }
+
+  function getView() {
+    return document.body?.dataset?.cpuView === 'archive' ? 'archive' : 'active';
+  }
+
+  async function loadActive() {
+    try {
+      const response = await fetch('/api/cpu/orders');
+      const payload = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        notify('Ошибка', payload?.message || 'Не удалось загрузить CPU заказы.', 'error');
+        return;
+      }
+      activeOrders = Array.isArray(payload?.orders) ? payload.orders : [];
+      renderActive();
+    } catch (error) {
+      notify('Ошибка', 'Сетевой сбой при загрузке активных CPU заказов.', 'error');
+    }
+  }
+
+  async function loadArchive() {
+    const params = new URLSearchParams({ query, manager, status });
+    try {
+      const response = await fetch(`/api/cpu/archive?${params.toString()}`);
+      const payload = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        notify('Ошибка', payload?.message || 'Не удалось загрузить архив CPU.', 'error');
+        return;
+      }
+      archiveOrders = Array.isArray(payload?.orders) ? payload.orders : [];
+      renderArchive();
+    } catch (error) {
+      notify('Ошибка', 'Сетевой сбой при загрузке архива CPU.', 'error');
+    }
+  }
+
+  function bindActions() {
+    const list = document.getElementById('cpuCardList');
+    if (!list) return;
+
+    list.addEventListener('click', async event => {
+      const btn = event.target.closest('button[data-action]');
+      if (!btn) return;
+
+      const action = btn.dataset.action;
+      const key = btn.dataset.orderKey;
+      if (!action || !key) return;
+
+      if (btn.disabled) return;
+
+      if (action === 'send') await sendOrder(key, btn);
+      if (action === 'confirm') await confirmOrder(key, btn);
+      if (action === 'assign') await assignManager(key, btn);
+    });
+  }
+
+  async function sendOrder(orderKey, btn) {
+    setLoading(btn, true);
+    try {
+      const response = await fetch(`/api/cpu/order/${encodeURIComponent(orderKey)}/send`, {
+        method: 'POST',
+        headers: withCsrfHeaders({ 'Content-Type': 'application/json' }),
+        body: JSON.stringify(withCsrfBody({}))
+      });
+      const payload = await response.json().catch(() => ({}));
+      if (response.status === 403) {
+        notify('Нет прав', 'У вас нет прав на отправку этого заказа.', 'error');
+        return;
+      }
+      if (!response.ok) {
+        notify('Ошибка', payload?.message || 'Не удалось отправить заказ.', 'error');
+        return;
+      }
+
+      await copyPath(payload?.full_path || '');
+      notify('Готово', 'Путь скопирован, заказ переведен на проверку.', 'success');
+      await loadActive();
+      if (getView() === 'archive') await loadArchive();
+    } finally {
+      setLoading(btn, false);
+    }
+  }
+
+  async function confirmOrder(orderKey, btn) {
+    setLoading(btn, true);
+    try {
+      const response = await fetch(`/api/cpu/order/${encodeURIComponent(orderKey)}/confirm`, {
+        method: 'POST',
+        headers: withCsrfHeaders({ 'Content-Type': 'application/json' }),
+        body: JSON.stringify(withCsrfBody({}))
+      });
+      const payload = await response.json().catch(() => ({}));
+      if (response.status === 403) {
+        notify('Нет прав', 'У вас нет прав на подтверждение этого заказа.', 'error');
+        return;
+      }
+      if (!response.ok) {
+        notify('Ошибка', payload?.message || 'Не удалось подтвердить заказ.', 'error');
+        return;
+      }
+
+      notify('Готово', 'Заказ подтвержден.', 'success');
+      await loadActive();
+      if (getView() === 'archive') await loadArchive();
+    } finally {
+      setLoading(btn, false);
+    }
+  }
+
+  async function assignManager(orderKey, btn) {
+    const managers = APP_CONFIG.managers || [];
+    if (!managers.length) {
+      notify('Ошибка', 'Список менеджеров пуст.', 'error');
+      return;
+    }
+    const current = btn.dataset.manager || '';
+    const candidate = window.prompt('Назначить менеджера:', current) || '';
+    const managerName = candidate.trim();
+    if (!managerName) return;
+
+    setLoading(btn, true);
+    try {
+      const response = await fetch(`/api/cpu/order/${encodeURIComponent(orderKey)}/assign-manager`, {
+        method: 'POST',
+        headers: withCsrfHeaders({ 'Content-Type': 'application/json' }),
+        body: JSON.stringify(withCsrfBody({ manager_name: managerName }))
+      });
+      const payload = await response.json().catch(() => ({}));
+      if (response.status === 403) {
+        notify('Нет прав', 'У вас нет прав на назначение менеджера.', 'error');
+        return;
+      }
+      if (!response.ok) {
+        notify('Ошибка', payload?.message || 'Не удалось назначить менеджера.', 'error');
+        return;
+      }
+
+      notify('Готово', 'Менеджер обновлен.', 'success');
+      await loadActive();
+      if (getView() === 'archive') await loadArchive();
+    } finally {
+      setLoading(btn, false);
+    }
+  }
+
+  async function copyPath(value) {
+    if (!value) return;
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(value);
+      return;
+    }
+    const ta = document.createElement('textarea');
+    ta.value = value;
+    ta.style.position = 'fixed';
+    ta.style.opacity = '0';
+    document.body.appendChild(ta);
+    ta.focus();
+    ta.select();
+    document.execCommand('copy');
+    ta.remove();
+  }
+
+  function setLoading(btn, loading) {
+    btn.disabled = !!loading;
+    btn.dataset.loading = loading ? '1' : '0';
+  }
+
+  function renderActive() {
+    const root = document.getElementById('cpuCardList');
+    if (!root) return;
+
+    if (!activeOrders.length) {
+      root.innerHTML = '<p class="hint">Активных CPU заказов нет.</p>';
+      return;
+    }
+
+    root.innerHTML = activeOrders.map(order => cardHtml(order, false)).join('');
+  }
+
+  function renderArchive() {
+    const root = document.getElementById('cpuCardList');
+    if (!root) return;
+
+    if (!archiveOrders.length) {
+      root.innerHTML = '<p class="hint">Архив пуст по текущим фильтрам.</p>';
+      return;
+    }
+
+    root.innerHTML = archiveOrders.map(order => cardHtml(order, true)).join('');
+  }
+
+  function cardHtml(order, archived) {
+    const statusValue = order?.status_cpu || '';
+    const isReview = statusValue === 'review';
+    const isConfirmed = statusValue === 'confirmed';
+
+    const currentUser = (APP_CONFIG.currentUser || '').trim().toLowerCase();
+    const currentRole = (APP_CONFIG.currentRole || '').trim().toLowerCase();
+    const managerName = (order?.manager_name || 'Неизвестно').trim();
+    const sameManager = currentUser && managerName.toLowerCase() === currentUser;
+
+    const canSend = order?.can_send !== undefined
+      ? !!order.can_send
+      : (currentRole === 'admin' || currentRole === 'technologist' || (currentRole === 'manager' && sameManager));
+    const canConfirm = order?.can_confirm !== undefined
+      ? !!order.can_confirm
+      : (currentRole === 'admin' || currentRole === 'technologist' || (currentRole === 'manager' && sameManager));
+    const canAssign = order?.can_assign !== undefined
+      ? !!order.can_assign
+      : (currentRole === 'admin' || currentRole === 'technologist');
+
+    const statusLabel = isConfirmed ? 'подтвержденный ✓' : (isReview ? 'на проверке' : 'готов');
+    const statusClass = isConfirmed ? 'status-pill status-pill--neutral' : 'status-pill status-pill--success';
+    const pdfLabel = order?.pdf_filename || order?.pdf_type_found || 'PDF найден';
+
+    return `
+      <article class="folder-card cpu-card">
+        <div class="folder-top">
+          <div>
+            <span class="folder-name">${escapeHtml(order?.folder_name || order?.order_key || '')}</span>
+            <span class="manager-label">👤 ${escapeHtml(managerName)}</span>
+          </div>
+          <span class="${statusClass}">${statusLabel}</span>
+        </div>
+
+        <div class="path-container cpu-card__meta">
+          <span class="path-text">PDF: ${escapeHtml(pdfLabel)}</span>
+          ${order?.sent_at ? `<span class="table-secondary">Отправлен: ${escapeHtml(formatShortDate(order.sent_at))}</span>` : ''}
+          ${order?.confirmed_at ? `<span class="table-secondary">Подтвержден: ${escapeHtml(formatShortDate(order.confirmed_at))}</span>` : ''}
+        </div>
+
+        ${archived ? '' : `
+          <div class="button-group cpu-card__actions">
+            <button type="button" class="btn btn--primary" data-action="send" data-order-key="${escapeHtml(order?.order_key || '')}" ${canSend ? '' : 'disabled title="нет прав"'}>Отправить</button>
+            <button type="button" class="btn btn--ghost" data-action="confirm" data-order-key="${escapeHtml(order?.order_key || '')}" ${canConfirm ? '' : 'disabled title="нет прав"'}>Подтвердил</button>
+            <button type="button" class="btn btn--ghost" data-action="assign" data-manager="${escapeHtml(managerName)}" data-order-key="${escapeHtml(order?.order_key || '')}" ${canAssign ? '' : 'disabled title="нет прав"'}>Назначить менеджера</button>
+          </div>
+        `}
+      </article>
+    `;
+  }
+
+  function escapeHtml(value) {
+    return String(value || '')
+      .replaceAll('&', '&amp;')
+      .replaceAll('<', '&lt;')
+      .replaceAll('>', '&gt;')
+      .replaceAll('"', '&quot;');
+  }
+
+  function formatShortDate(value) {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return value || '—';
+    const dd = String(date.getDate()).padStart(2, '0');
+    const mm = String(date.getMonth() + 1).padStart(2, '0');
+    const yyyy = date.getFullYear();
+    const hh = String(date.getHours()).padStart(2, '0');
+    const min = String(date.getMinutes()).padStart(2, '0');
+    return `${dd}.${mm}.${yyyy} ${hh}:${min}`;
+  }
+
+  function notify(title, desc, type = 'info') {
+    const stack = document.getElementById('toastStack');
+    if (!stack) {
+      alert(desc || title);
+      return;
+    }
+
+    const toast = document.createElement('div');
+    toast.className = `toast toast--${type}`;
+    toast.innerHTML = `
+      <div class="toast__title">${escapeHtml(title || 'Сообщение')}</div>
+      <div class="toast__desc">${escapeHtml(desc || '')}</div>
+      <button class="toast__close" aria-label="Закрыть">✕</button>
+    `;
+    toast.querySelector('.toast__close')?.addEventListener('click', () => toast.remove());
+    stack.appendChild(toast);
+    requestAnimationFrame(() => toast.classList.add('is-visible'));
+    setTimeout(() => toast.remove(), 4200);
+  }
+
+  return { init };
+})();
+
+document.addEventListener('DOMContentLoaded', () => {
+  CpuPage.init();
+});

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -2345,3 +2345,16 @@ code {
 .role-card--creation .role-card__footer .btn:active{
   transform: translateY(1px);
 }
+
+.cpu-card {
+  background: rgba(14, 165, 233, 0.08);
+  border-color: rgba(14, 165, 233, 0.2);
+}
+
+.cpu-card__meta {
+  margin-bottom: 10px;
+}
+
+.cpu-card__actions {
+  margin-top: 10px;
+}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -33,6 +33,7 @@
       {% if role_perms.can_access_search %}
       <a href="/search">🔍 Поиск</a>
       {% endif %}
+      <a href="/cpu">🧠 CPU</a>
       {% if role_perms.can_access_facades %}
       <a href="/facades">🚪 Фасады</a>
       {% endif %}

--- a/app/templates/cpu.html
+++ b/app/templates/cpu.html
@@ -1,0 +1,56 @@
+{% extends "base.html" %}
+
+{% block title %}DESENE CPU мониторинг{% endblock %}
+
+{% block body_attrs %}
+data-page="cpu"
+data-managers='{{ config_managers | tojson }}'
+data-cpu-view="{{ cpu_view or 'active' }}"
+{% endblock %}
+
+{% block content %}
+  <header class="page-header">
+    <h1>🧠 DESENE CPU мониторинг</h1>
+    <p class="page-description">
+      Контроль заказов с найденным CPU PDF. Используйте активный список для отправки и подтверждения,
+      архив — для проверки истории.
+    </p>
+  </header>
+
+  <section class="card controls-card">
+    <div class="controls-grid">
+      <div class="button-group">
+        <a href="{{ url_for('cpu.cpu_page') }}" class="btn btn--ghost {% if (cpu_view or 'active') == 'active' %}is-active{% endif %}">Активные</a>
+        <a href="{{ url_for('cpu.cpu_archive_page') }}" class="btn btn--ghost {% if (cpu_view or 'active') == 'archive' %}is-active{% endif %}">Архив</a>
+      </div>
+
+      <div class="filter-search" id="cpuArchiveSearchWrap" {% if (cpu_view or 'active') != 'archive' %}hidden{% endif %}>
+        <label class="field-label" for="cpuArchiveSearch">Поиск</label>
+        <input type="search" id="cpuArchiveSearch" class="input input--compact search-grow" placeholder="Номер, имя, префикс" autocomplete="off">
+      </div>
+
+      <div class="controls-actions" id="cpuArchiveFiltersWrap" {% if (cpu_view or 'active') != 'archive' %}hidden{% endif %}>
+        <label class="field" for="cpuArchiveManager">
+          <span class="field-label">Менеджер</span>
+          <select id="cpuArchiveManager" class="select">
+            <option value="">Все</option>
+            {% for manager in config_managers %}
+            <option value="{{ manager }}">{{ manager }}</option>
+            {% endfor %}
+            <option value="Неизвестно">Неизвестно</option>
+          </select>
+        </label>
+        <label class="field" for="cpuArchiveStatus">
+          <span class="field-label">Статус</span>
+          <select id="cpuArchiveStatus" class="select">
+            <option value="">Все</option>
+            <option value="review">На проверке</option>
+            <option value="confirmed">Подтвержденный</option>
+          </select>
+        </label>
+      </div>
+    </div>
+  </section>
+
+  <section class="card" id="cpuCardList"></section>
+{% endblock %}

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -94,6 +94,20 @@ data-managers='{{ config_managers | tojson }}'
         </div>
 
         <div class="settings-field settings-field--wide">
+          <label class="field-label" for="desene_cpu_root">DESENE CPU: путь к папке</label>
+          <input type="text" class="input" id="desene_cpu_root" name="desene_cpu_root" placeholder="\\SERVER\homag\DESENE CPU\2025" value="{{ config.get('paths', {}).get('desene_cpu_root', '') }}">
+          <p class="hint">Используется мониторингом CPU для поиска готовых PDF по заказам.</p>
+        </div>
+
+        <div class="settings-field settings-field--wide">
+          <label class="checkbox-row">
+            <input type="checkbox" name="cpu_monitoring_enabled" {% if config.get('features', {}).get('cpu_monitoring_enabled', False) %}checked{% endif %}>
+            <span>Включить DESENE CPU мониторинг</span>
+          </label>
+          <p class="hint">Права на действия задаются ролями в системе и проверяются сервером.</p>
+        </div>
+
+        <div class="settings-field settings-field--wide">
           <label class="field-label" for="search_folders">Папки для поиска (Название=Путь)</label>
           <textarea id="search_folders" name="search_folders" class="input input--mono" placeholder="Название=\\\\SERVER\\path">{{ search_text }}</textarea>
           <p class="hint">Используйте по одному пути в строке: <code>Название=\\\\server\\share</code>.</p>


### PR DESCRIPTION
### Motivation
- Provide a lightweight UI for DESENE CPU monitoring to view active CPU-ready orders and an archive, using existing backend endpoints and preserving current styles and components. 
- Allow users to send/confirm CPU orders and assign managers from the UI while respecting existing server-side permissions and role rules.

### Description
- Added two new routes and a template to expose the UI: `GET /cpu` and `GET /cpu/archive` render `cpu.html` with active/archive view toggles. 
- Implemented the frontend logic in `app/static/script.js` as `CpuPage` to fetch `GET /api/cpu/orders` and `GET /api/cpu/archive?query=&status=&manager=`, perform actions via `POST /api/cpu/order/<id>/send`, `POST /api/cpu/order/<id>/confirm`, and `POST /api/cpu/order/<id>/assign-manager`, copy `full_path` to clipboard after send, and handle 403 responses with toast notifications. 
- Reused existing UI primitives (cards, badges, filters, toasts, manager lists) and added small CSS rules in `app/static/style.css` for CPU cards; no existing classes/IDs were changed. 
- Extended settings UI `app/templates/settings.html` with `desene_cpu_root` input and `cpu_monitoring_enabled` checkbox, and added a top-menu link to CPU in `app/templates/base.html`. 
- Files added/modified: `app/routes/cpu.py` (routes + render), `app/templates/cpu.html` (new), `app/templates/base.html` (nav link), `app/templates/settings.html` (DESENE CPU settings), `app/static/script.js` (CpuPage JS), `app/static/style.css` (CPU card styles). 

### Testing
- Compiled Python sources with `python -m compileall app` which succeeded. 
- Compiled modified route file with `python -m compileall app/routes/cpu.py` which succeeded. 
- Attempted to run the application (`BAZIS_DISABLE_BACKGROUND=1 python run.py`) for a live smoke test but startup failed due to a missing environment dependency (`ModuleNotFoundError: No module named 'certifi'`), so full browser verification was not performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a09cd1c064832db46a865971b0edc5)