### PR TITLE
Fix CPU monitor path usage and archive grouping by month

### DIFF
--- a/app/dal/cpu_orders.py
+++ b/app/dal/cpu_orders.py
@@ -15,6 +15,8 @@ class CpuOrder(Base):
     folder_name = Column(String, nullable=False)
     full_path = Column(Text, nullable=False)
     year_month_path = Column(String, nullable=True)
+    year = Column(String, nullable=True)
+    month_folder = Column(String, nullable=True)
 
     pdf_visible = Column(Boolean, nullable=False, default=False)
     pdf_type_found = Column(String, nullable=True)
@@ -78,7 +80,14 @@ def list_cpu_archive_orders(query: str = "", status: str = "", manager: str = ""
                 )
             )
 
-        return db_query.order_by(CpuOrder.updated_at.desc(), CpuOrder.created_at.desc()).all()
+        return (
+            db_query.order_by(
+                CpuOrder.year.desc(),
+                CpuOrder.month_folder.desc(),
+                CpuOrder.updated_at.desc(),
+                CpuOrder.created_at.desc(),
+            ).all()
+        )
 
 
 def upsert_cpu_order(
@@ -91,6 +100,8 @@ def upsert_cpu_order(
     pdf_type_found: str,
     pdf_filename: str,
     manager_name: str,
+    year: int | None = None,
+    month_folder: str = "",
     status_cpu: str = "ready",
     missing_path: bool = False,
 ) -> CpuOrder:
@@ -104,6 +115,8 @@ def upsert_cpu_order(
         record.folder_name = folder_name
         record.full_path = full_path
         record.year_month_path = year_month_path
+        record.year = str(year) if year else None
+        record.month_folder = month_folder or None
         record.pdf_visible = bool(pdf_visible)
         record.pdf_type_found = pdf_type_found or None
         record.pdf_filename = pdf_filename or None

--- a/app/dal/db.py
+++ b/app/dal/db.py
@@ -223,6 +223,29 @@ def _ensure_role_permissions_columns() -> None:
         raise
 
 
+def _ensure_cpu_orders_columns() -> None:
+    """Гарантирует наличие колонок группировки архива CPU."""
+
+    inspector = inspect(engine)
+    columns = {col["name"] for col in inspector.get_columns("cpu_orders")}
+    required_columns = {
+        "year": "TEXT",
+        "month_folder": "TEXT",
+    }
+    missing = [name for name in required_columns if name not in columns]
+    if not missing:
+        return
+
+    logging.getLogger("bazis").info(
+        "[db] Добавляем отсутствующие колонки в cpu_orders: %s", ", ".join(missing)
+    )
+    with engine.begin() as conn:
+        for column_name in missing:
+            conn.exec_driver_sql(
+                f"ALTER TABLE cpu_orders ADD COLUMN {column_name} {required_columns[column_name]}"
+            )
+
+
 def init_db() -> None:
     os.makedirs(BASE_DIR, exist_ok=True)
     # Регистрируем все модели, зависящие от Base, перед созданием таблиц
@@ -234,6 +257,7 @@ def init_db() -> None:
 
     Base.metadata.create_all(engine)
     _ensure_role_permissions_columns()
+    _ensure_cpu_orders_columns()
     _create_default_admin()
     _ensure_default_role_permissions()
 

--- a/app/routes/cpu.py
+++ b/app/routes/cpu.py
@@ -60,6 +60,8 @@ def _serialize(row) -> dict:
         "folder_name": row.folder_name,
         "full_path": row.full_path,
         "year_month_path": row.year_month_path or "",
+        "year": int(row.year) if str(row.year or "").isdigit() else None,
+        "month_folder": row.month_folder or "",
         "pdf_visible": bool(row.pdf_visible),
         "pdf_type_found": row.pdf_type_found or "",
         "pdf_filename": row.pdf_filename or "",
@@ -92,7 +94,21 @@ def cpu_archive():
     sync_cpu_orders()
     rows = list_cpu_archive_orders(query=query, status=status, manager=manager)
     visible = [_serialize(row) for row in rows if _can_view_order(_serialize(row))]
-    return jsonify({"status": "ok", "orders": visible})
+
+    grouped: dict[tuple[int, str], list[dict]] = {}
+    for order in visible:
+        year = order.get("year")
+        month_folder = order.get("month_folder") or ""
+        key = (year or 0, month_folder)
+        grouped.setdefault(key, []).append(order)
+
+    groups = [
+        {"year": year, "month_folder": month_folder, "items": items}
+        for (year, month_folder), items in grouped.items()
+    ]
+    groups.sort(key=lambda item: (item.get("year") or 0, item.get("month_folder") or ""), reverse=True)
+
+    return jsonify({"status": "ok", "orders": visible, "groups": groups})
 
 
 @cpu_bp.route("/api/cpu/order/<order_key>/send", methods=["POST"])

--- a/app/services/cpu_monitor.py
+++ b/app/services/cpu_monitor.py
@@ -5,6 +5,7 @@ import os
 import threading
 import time
 from dataclasses import dataclass
+from datetime import datetime
 
 import app.config as app_config
 from app import get_manager_from_name, logger
@@ -33,6 +34,22 @@ def _is_year_folder(name: str) -> bool:
     return name.isdigit() and len(name) == 4
 
 
+def _extract_order_number(folder_name: str) -> str:
+    # Берем префикс до первого пробела как номер заказа (если он есть).
+    return (folder_name.split(" ", 1)[0] if " " in folder_name else "").strip()
+
+
+def _parse_year_month_from_rel_path(year_month_path: str) -> tuple[int | None, str]:
+    parts = [part for part in (year_month_path or "").split(os.sep) if part]
+    if len(parts) < 2:
+        return None, ""
+
+    year_raw, month_folder = parts[0].strip(), parts[1].strip()
+    if not (_is_year_folder(year_raw) and month_folder):
+        return None, ""
+    return int(year_raw), month_folder
+
+
 def _find_pdf_match(order_folder_path: str, folder_name: str) -> CpuPdfMatch:
     try:
         files = [entry.name for entry in os.scandir(order_folder_path) if entry.is_file()]
@@ -51,34 +68,68 @@ def _find_pdf_match(order_folder_path: str, folder_name: str) -> CpuPdfMatch:
         name = files_map[lowered_order_pdf]
         return CpuPdfMatch(visible=True, pdf_type="folder.pdf", pdf_filename=name)
 
-    if " " in folder_name:
-        order_number = folder_name.split(" ", 1)[0].strip()
-        if order_number:
-            num_pdf = f"{order_number}.pdf".lower()
-            if num_pdf in files_map:
-                name = files_map[num_pdf]
-                return CpuPdfMatch(visible=True, pdf_type="order.pdf", pdf_filename=name)
+    order_number = _extract_order_number(folder_name)
+    if order_number:
+        num_pdf = f"{order_number}.pdf".lower()
+        if num_pdf in files_map:
+            name = files_map[num_pdf]
+            return CpuPdfMatch(visible=True, pdf_type="order.pdf", pdf_filename=name)
+
+        # Расширенная проверка: любой PDF, начинающийся с номера заказа.
+        for lowered_name, original_name in files_map.items():
+            if not lowered_name.endswith(".pdf"):
+                continue
+            if lowered_name.startswith(order_number.lower()):
+                return CpuPdfMatch(visible=True, pdf_type="order-prefix.pdf", pdf_filename=original_name)
+
+    # Доп.проверка: совпадение имени файла с полной папкой (без учета регистра).
+    for lowered_name, original_name in files_map.items():
+        if lowered_name == lowered_order_pdf:
+            return CpuPdfMatch(visible=True, pdf_type="folder.pdf", pdf_filename=original_name)
 
     return CpuPdfMatch(visible=False, pdf_type="", pdf_filename="")
 
 
+def _detect_month_folder(root_path: str) -> tuple[str | None, str]:
+    """Возвращает путь до папки месяца и относительный year/month путь."""
+
+    norm_root = os.path.normpath(root_path)
+    parts = [part for part in norm_root.split(os.sep) if part]
+    if len(parts) >= 2 and _is_year_folder(parts[-2]):
+        # В settings задан конкретный месяц: .../<year>/<month>
+        return norm_root, os.path.join(parts[-2], parts[-1])
+
+    current = datetime.now()
+    year_folder = str(current.year)
+    year_path = os.path.join(norm_root, year_folder)
+    if not os.path.isdir(year_path):
+        return None, ""
+
+    month_prefix = f"{current.month:02d}."
+    candidates = [
+        item
+        for item in os.listdir(year_path)
+        if os.path.isdir(os.path.join(year_path, item)) and item.startswith(month_prefix)
+    ]
+    if not candidates:
+        return None, ""
+
+    month_name = sorted(candidates)[-1]
+    return os.path.join(year_path, month_name), os.path.join(year_folder, month_name)
+
+
 def _iter_order_folders(root_path: str):
-    for year in sorted(os.listdir(root_path)):
-        year_path = os.path.join(root_path, year)
-        if not os.path.isdir(year_path) or not _is_year_folder(year):
+    month_path, year_month_path = _detect_month_folder(root_path)
+    if not month_path:
+        logger.debug("[cpu-monitor] month folder not detected from root='%s'", root_path)
+        return
+
+    logger.debug("[cpu-monitor] scanning month_path='%s' (year_month='%s')", month_path, year_month_path)
+
+    for entry in os.scandir(month_path):
+        if not entry.is_dir():
             continue
-
-        for month_name in sorted(os.listdir(year_path)):
-            month_path = os.path.join(year_path, month_name)
-            if not os.path.isdir(month_path):
-                continue
-
-            year_month_path = os.path.join(year, month_name)
-            for order_name in os.listdir(month_path):
-                order_path = os.path.join(month_path, order_name)
-                if not os.path.isdir(order_path):
-                    continue
-                yield order_name, order_path, year_month_path
+        yield entry.name, entry.path, year_month_path
 
 
 def sync_cpu_orders() -> dict[str, int]:
@@ -86,20 +137,32 @@ def sync_cpu_orders() -> dict[str, int]:
     if not app_config.CONFIG.get("features", {}).get("cpu_monitoring_enabled", False):
         return {"processed": 0, "visible": 0, "missing": 0}
 
-    if not root_path or not os.path.isdir(root_path):
+    if not root_path:
+        logger.debug("[cpu-monitor] root path is empty in settings")
+        return {"processed": 0, "visible": 0, "missing": 0}
+
+    path_exists = os.path.isdir(root_path)
+    logger.debug("[cpu-monitor] settings path='%s', exists=%s", root_path, path_exists)
+    if not path_exists:
         return {"processed": 0, "visible": 0, "missing": 0}
 
     processed = 0
     visible = 0
     seen_keys: set[str] = set()
+    order_folder_count = 0
+    pdf_visible_count = 0
 
     batch: list[dict] = []
     for folder_name, full_path, year_month_path in _iter_order_folders(root_path):
+        order_folder_count += 1
         order_key = build_cpu_order_key(full_path)
         seen_keys.add(order_key)
 
         pdf_match = _find_pdf_match(full_path, folder_name)
+        if pdf_match.visible:
+            pdf_visible_count += 1
         manager_name = get_manager_from_name(folder_name)
+        year, month_folder = _parse_year_month_from_rel_path(year_month_path)
 
         batch.append(
             {
@@ -111,8 +174,16 @@ def sync_cpu_orders() -> dict[str, int]:
                 "pdf_type_found": pdf_match.pdf_type,
                 "pdf_filename": pdf_match.pdf_filename,
                 "manager_name": manager_name,
+                "year": year,
+                "month_folder": month_folder,
             }
         )
+
+    logger.debug(
+        "[cpu-monitor] folders_found=%s, pdf_visible=%s",
+        order_folder_count,
+        pdf_visible_count,
+    )
 
     overrides = get_overrides_map([item["order_key"] for item in batch])
 
@@ -134,6 +205,14 @@ def sync_cpu_orders() -> dict[str, int]:
 
     missing = existing - seen_keys
     mark_cpu_order_missing(missing)
+
+    logger.debug(
+        "[cpu-monitor] persisted processed=%s, active_visible=%s, archive_candidates=%s, missing=%s",
+        processed,
+        visible,
+        len(batch) - visible,
+        len(missing),
+    )
 
     return {"processed": processed, "visible": visible, "missing": len(missing)}
 

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -2001,6 +2001,7 @@ document.addEventListener('DOMContentLoaded', () => {
 const CpuPage = (() => {
   let activeOrders = [];
   let archiveOrders = [];
+  let archiveGroups = [];
   let query = '';
   let manager = '';
   let status = '';
@@ -2069,6 +2070,7 @@ const CpuPage = (() => {
         return;
       }
       archiveOrders = Array.isArray(payload?.orders) ? payload.orders : [];
+      archiveGroups = Array.isArray(payload?.groups) ? payload.groups : [];
       renderArchive();
     } catch (error) {
       notify('Ошибка', 'Сетевой сбой при загрузке архива CPU.', 'error');
@@ -2222,12 +2224,48 @@ const CpuPage = (() => {
     const root = document.getElementById('cpuCardList');
     if (!root) return;
 
-    if (!archiveOrders.length) {
+    const groups = normalizeArchiveGroups();
+    if (!groups.length) {
       root.innerHTML = '<p class="hint">Архив пуст по текущим фильтрам.</p>';
       return;
     }
 
-    root.innerHTML = archiveOrders.map(order => cardHtml(order, true)).join('');
+    root.innerHTML = groups.map(group => archiveGroupHtml(group)).join('');
+  }
+
+  function normalizeArchiveGroups() {
+    if (archiveGroups.length) return archiveGroups;
+    if (!archiveOrders.length) return [];
+
+    const fallback = new Map();
+    for (const item of archiveOrders) {
+      const year = Number.isFinite(item?.year) ? item.year : 0;
+      const monthFolder = item?.month_folder || 'Без месяца';
+      const key = `${year}__${monthFolder}`;
+      if (!fallback.has(key)) fallback.set(key, { year, month_folder: monthFolder, items: [] });
+      fallback.get(key).items.push(item);
+    }
+    return Array.from(fallback.values()).sort((a, b) => {
+      if ((b.year || 0) !== (a.year || 0)) return (b.year || 0) - (a.year || 0);
+      return String(b.month_folder || '').localeCompare(String(a.month_folder || ''), 'ru');
+    });
+  }
+
+  function archiveGroupHtml(group) {
+    const label = [group?.month_folder || 'Без месяца', group?.year || ''].filter(Boolean).join(' · ');
+    const now = new Date();
+    const currentYear = now.getFullYear();
+    const currentMonth = String(now.getMonth() + 1).padStart(2, '0');
+    const isCurrent = Number(group?.year) === currentYear && String(group?.month_folder || '').startsWith(`${currentMonth}.`);
+    const openAttr = isCurrent ? ' open' : '';
+    const items = Array.isArray(group?.items) ? group.items : [];
+
+    return `
+      <details class="card"${openAttr}>
+        <summary><strong>${escapeHtml(label)}</strong> (${items.length})</summary>
+        <div class="cpu-archive-group-items">${items.map(order => cardHtml(order, true)).join('')}</div>
+      </details>
+    `;
   }
 
   function cardHtml(order, archived) {


### PR DESCRIPTION
### Motivation
- Active list was empty because the CPU scanner did not reliably use the path from settings and did not scan the actual month folder structure configured in `desene_cpu_root`.
- The PDF visibility gate and archive grouping need to remain deterministic: orders must be visible only when a qualifying PDF is present and archive must be stable by month/year.
- Keep backward compatibility: do not change settings format, CSS classes/IDs or external API behavior unnecessarily, while making archive grouping easier to consume.

### Description
- Read and resolve the configured CPU path more robustly in `app/services/cpu_monitor.py`: detect when settings point to a concrete month folder (`.../YYYY/<MM. Month YYYY>`) versus the DESENE CPU root and resolve the current month when required; scan only first-level order folders inside the resolved month folder and add debug logs for each stage of resolution and scanning.
- Harden PDF-gate in `app/services/cpu_monitor.py`: case-insensitive `CPU.pdf`, `{folder_name}.pdf`, `{order_number}.pdf`, any PDF starting with the extracted order number, and preserve the rule "visible only if PDF".
- Persist month grouping metadata: add `year` and `month_folder` columns to the `CpuOrder` model in `app/dal/cpu_orders.py` and write these fields during `upsert_cpu_order` for stable grouping even if the path disappears.
- Add safe SQLite migration helper in `app/dal/db.py` to `ALTER TABLE` and add missing `year`/`month_folder` columns when initializing the DB.
- Extend the archive API in `app/routes/cpu.py` to return grouped data as `groups: [{ year, month_folder, items: [...] }]` while keeping the original `orders` list for backward compatibility.
- Update front-end rendering in `app/static/script.js` to consume `groups` and render archive month sections using `<details>` blocks (auto-open current month), with a fallback grouping when `groups` is not provided by the server.
- Minimal, local changes only; settings storage format and external API endpoints remain compatible and no CSS classes/IDs were changed.
- Files changed: `app/services/cpu_monitor.py`, `app/dal/cpu_orders.py`, `app/dal/db.py`, `app/routes/cpu.py`, `app/static/script.js`.

### Testing
- Ran Python byte-compile for modified modules with `python -m py_compile app/services/cpu_monitor.py app/dal/cpu_orders.py app/routes/cpu.py app/dal/db.py` and it succeeded for those modules.
- Ran `pytest -q` and the test runner reported no tests were discovered in the repository (no failures from test suite execution).
- Executed an automated Playwright navigation attempt to `http://127.0.0.1:5000/cpu/archive`, which failed because the application process could not be started in this environment (server startup failed due to a missing runtime dependency); this is an environment issue rather than a code regression.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0a7314678832da1795bd32aa780f0)