### PR TITLE
Add DESENE CPU monitor module with PDF-gated scanning, RBAC, workflow and archive

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -45,6 +45,12 @@ DEFAULT_CONFIG = {
     "orders_auto_confirm": {
         "path_not_given_folder": "",
     },
+    "desene_cpu": {
+        "scan_mode": "recent",
+        "scan_months": 3,
+        "selected_months": [],
+        "manager_tags": {},
+    },
 }
 
 logger = logging.getLogger("bazis")
@@ -318,6 +324,13 @@ def _ensure_complete_config(raw_config: dict) -> dict:
     merged["orders_auto_confirm"]["path_not_given_folder"] = str(
         merged["orders_auto_confirm"].get("path_not_given_folder") or ""
     ).strip()
+
+    merged.setdefault("desene_cpu", {})
+    merged["desene_cpu"]["scan_mode"] = str(merged["desene_cpu"].get("scan_mode") or "recent").strip().lower()
+    merged["desene_cpu"]["scan_months"] = max(1, min(12, _parse_int(merged["desene_cpu"].get("scan_months"), 3)))
+    selected = merged["desene_cpu"].get("selected_months")
+    merged["desene_cpu"]["selected_months"] = selected if isinstance(selected, list) else []
+    merged["desene_cpu"]["manager_tags"] = _parse_str_dict(merged["desene_cpu"].get("manager_tags"))
     return merged
 
 

--- a/app/routes/orders.py
+++ b/app/routes/orders.py
@@ -42,6 +42,7 @@ from app.services.snapshot import (
 )
 from app.services.order_times import normalize_order_key
 from app.services.audit import log_order_event
+from app.services import cpu_monitor
 from app.services.telegram import (
     folder_has_ready_marker,
     technologist_from_folder,
@@ -425,6 +426,79 @@ def generate_facades():
             or os.path.dirname(os.path.abspath(app_config.FACADES_FILE)),
         }
     )
+
+
+@orders_bp.route("/cpu")
+def cpu_monitor_page():
+    payload = cpu_monitor.scan_cpu_orders(force=True)
+    return render_template("cpu_monitor.html", cpu_data=payload, managers=app_config.MANAGER_NAMES)
+
+
+@orders_bp.route("/cpu/archive")
+def cpu_archive_page():
+    payload = cpu_monitor.scan_cpu_orders(force=True)
+    query = (request.args.get("q") or "").strip().lower()
+    archive = payload.get("archive") or []
+    if query:
+        archive = [
+            item
+            for item in archive
+            if query in (item.get("folder_name") or "").lower()
+            or query in (item.get("owner_manager") or "").lower()
+            or query in (item.get("status") or "").lower()
+            or query in (item.get("order_key") or "").lower()
+        ]
+    grouped = {}
+    for item in archive:
+        y = str(item.get("year") or "—")
+        m = item.get("month_label") or "—"
+        grouped.setdefault(y, {})
+        grouped[y].setdefault(m, [])
+        grouped[y][m].append(item)
+    return render_template("cpu_archive.html", archive_grouped=grouped, query=query)
+
+
+@orders_bp.route("/api/cpu/data")
+def cpu_data():
+    payload = cpu_monitor.scan_cpu_orders(force=False)
+    return jsonify({"status": "ok", **payload})
+
+
+@orders_bp.route("/api/cpu/<order_key>/send", methods=["POST"])
+def cpu_send(order_key: str):
+    ok, message = validate_csrf_token()
+    if not ok:
+        return csrf_error_response(message)
+    success, error, item = cpu_monitor.send_to_customer(order_key, session.get("role") or "", session.get("user") or "")
+    if not success:
+        return jsonify({"status": "error", "message": error}), 403
+    return jsonify({"status": "ok", "order": item, "copy_path": (item or {}).get("path") or ""})
+
+
+@orders_bp.route("/api/cpu/<order_key>/confirm", methods=["POST"])
+def cpu_confirm(order_key: str):
+    ok, message = validate_csrf_token()
+    if not ok:
+        return csrf_error_response(message)
+    success, error, item = cpu_monitor.confirm_order(order_key, session.get("role") or "", session.get("user") or "")
+    if not success:
+        return jsonify({"status": "error", "message": error}), 403
+    return jsonify({"status": "ok", "order": item})
+
+
+@orders_bp.route("/api/cpu/<order_key>/manager", methods=["POST"])
+def cpu_assign_manager(order_key: str):
+    ok, message = validate_csrf_token()
+    if not ok:
+        return csrf_error_response(message)
+    payload = request.get_json(silent=True) or {}
+    manager_name = str(payload.get("manager") or "").strip()
+    if not manager_name:
+        return jsonify({"status": "error", "message": "Менеджер не задан"}), 400
+    item = cpu_monitor.assign_manager(order_key, manager_name, session.get("user") or "")
+    if not item:
+        return jsonify({"status": "error", "message": "Заказ не найден"}), 404
+    return jsonify({"status": "ok", "order": item})
 
 
 @orders_bp.route("/ping", methods=["GET"])

--- a/app/routes/settings.py
+++ b/app/routes/settings.py
@@ -147,6 +147,10 @@ def settings_page():
             plus_rename = request.form.get("orders_plus_rename") == "on"
             anulat_rename = request.form.get("orders_anulat_rename") == "on"
             not_given_folder = request.form.get("not_given_folder_path", "").strip()
+            cpu_scan_mode = request.form.get("desene_cpu_scan_mode", "recent").strip().lower()
+            cpu_scan_months_raw = request.form.get("desene_cpu_scan_months", "3").strip()
+            cpu_selected_months = request.form.getlist("desene_cpu_selected_months")
+            cpu_manager_tags_raw = request.form.get("desene_cpu_manager_tags", "").strip()
 
             telegram_token = request.form.get("telegram_token", "").strip()
             telegram_chat_raw = request.form.get("telegram_chat_id", "").strip()
@@ -213,6 +217,15 @@ def settings_page():
 
             auto_confirm_cfg = updated.setdefault("orders_auto_confirm", {})
             auto_confirm_cfg["path_not_given_folder"] = not_given_folder
+
+            desene_cpu_cfg = updated.setdefault("desene_cpu", {})
+            desene_cpu_cfg["scan_mode"] = cpu_scan_mode if cpu_scan_mode in {"current", "recent", "manual"} else "recent"
+            try:
+                desene_cpu_cfg["scan_months"] = max(1, min(12, int(cpu_scan_months_raw or "3")))
+            except (TypeError, ValueError):
+                desene_cpu_cfg["scan_months"] = 3
+            desene_cpu_cfg["selected_months"] = [item for item in cpu_selected_months if item]
+            desene_cpu_cfg["manager_tags"] = parse_mapping(cpu_manager_tags_raw)
 
         if not errors:
             save_config(updated)
@@ -307,6 +320,15 @@ def settings_page():
         f"{title}={path}" for title, path in (search_source or {}).items()
     )
 
+    now = time.localtime()
+    cpu_month_choices = []
+    for offset in range(0, 12):
+        total = now.tm_year * 12 + (now.tm_mon - 1) - offset
+        year = total // 12
+        month = total % 12 + 1
+        label = f"{year}-{month:02d}"
+        cpu_month_choices.append(label)
+
     users = get_all_users()
     available_roles = sorted(get_allowed_roles())
     audit_events = fetch_events(limit=120)
@@ -330,6 +352,7 @@ def settings_page():
         protected_roles=set(DEFAULT_ROLE_PERMISSIONS.keys()),
         role_usage={user["role"] for user in users},
         audit_events=audit_events,
+        cpu_month_choices=cpu_month_choices,
     )
 
 

--- a/app/services/cpu_monitor.py
+++ b/app/services/cpu_monitor.py
@@ -1,0 +1,388 @@
+import os
+import re
+import threading
+import time
+from datetime import datetime
+from typing import Dict, List, Optional, Tuple
+
+import app
+import app.config as app_config
+from app.dal.json_store import load_json_file, save_json_atomic
+from app.paths import resolve_path
+from app.services.audit import log_order_event
+
+CPU_STATE_FILE = resolve_path("cpu_monitor_state.json")
+
+MONTH_NAMES_RO = {
+    1: "Ianuarie",
+    2: "Februarie",
+    3: "Martie",
+    4: "Aprilie",
+    5: "Mai",
+    6: "Iunie",
+    7: "Iulie",
+    8: "August",
+    9: "Septembrie",
+    10: "Octombrie",
+    11: "Noiembrie",
+    12: "Decembrie",
+}
+
+_state_lock = threading.RLock()
+_scan_lock = threading.Lock()
+_state: Dict = {"orders": {}, "manager_overrides": {}, "pdf_cache": {}, "updated_at": 0}
+_last_scan_ts = 0.0
+_SCAN_TTL = 10.0
+
+
+def _normalize_spaces(value: str) -> str:
+    return " ".join((value or "").split())
+
+
+def _strip_manager_suffix(folder_name: str) -> Tuple[str, str]:
+    normalized = _normalize_spaces(folder_name)
+    match = re.search(r"\s*\[([^\]]+)\]\s*$", normalized)
+    if not match:
+        return normalized, ""
+    base = _normalize_spaces(normalized[: match.start()])
+    tag = (match.group(1) or "").strip()
+    return base, tag
+
+
+def _extract_order_key(folder_name: str) -> str:
+    base, _ = _strip_manager_suffix(folder_name)
+    base = _normalize_spaces(base)
+    match = re.match(r"^([0-9]+-[0-9]+)\s+(.+)$", base)
+    if match:
+        return f"{match.group(1).upper()}|{_normalize_spaces(match.group(2)).upper()}"
+    return base.upper()
+
+
+def _build_pdf_candidates(folder_name: str) -> List[str]:
+    base, _ = _strip_manager_suffix(folder_name)
+    full_norm = _normalize_spaces(folder_name)
+    base_norm = _normalize_spaces(base)
+    return ["CPU.pdf", f"{base_norm}.pdf", f"{full_norm}.pdf"]
+
+
+def _load_state() -> None:
+    loaded = load_json_file(CPU_STATE_FILE)
+    if isinstance(loaded, dict):
+        with _state_lock:
+            _state.clear()
+            _state.update(
+                {
+                    "orders": loaded.get("orders") or {},
+                    "manager_overrides": loaded.get("manager_overrides") or {},
+                    "pdf_cache": loaded.get("pdf_cache") or {},
+                    "updated_at": loaded.get("updated_at") or 0,
+                }
+            )
+
+
+def _save_state() -> None:
+    with _state_lock:
+        payload = {
+            "orders": _state.get("orders") or {},
+            "manager_overrides": _state.get("manager_overrides") or {},
+            "pdf_cache": _state.get("pdf_cache") or {},
+            "updated_at": int(time.time()),
+        }
+    save_json_atomic(CPU_STATE_FILE, payload)
+
+
+def _resolve_owner_manager(folder_name: str, order_key: str) -> str:
+    with _state_lock:
+        manual = (_state.get("manager_overrides") or {}).get(order_key)
+    if manual:
+        return manual
+
+    base, tag = _strip_manager_suffix(folder_name)
+    tag_mapping = (app_config.CONFIG.get("desene_cpu", {}) or {}).get("manager_tags") or {}
+    if tag and isinstance(tag_mapping, dict):
+        manager_from_tag = str(tag_mapping.get(tag) or "").strip()
+        if manager_from_tag:
+            return manager_from_tag
+
+    manager = app.get_manager_from_name(base)
+    return manager if manager else "Не назначен"
+
+
+def _month_label(year: int, month: int) -> str:
+    return f"{month:02d}. {MONTH_NAMES_RO.get(month, '')} {year}"
+
+
+def _iter_month_paths(root: str) -> List[Tuple[int, int, str]]:
+    cfg = app_config.CONFIG.get("desene_cpu", {}) if isinstance(app_config.CONFIG, dict) else {}
+    mode = str(cfg.get("scan_mode") or "recent").strip().lower()
+    months_count = max(1, min(12, int(cfg.get("scan_months") or 3)))
+    selected = cfg.get("selected_months") or []
+
+    now = datetime.now()
+    targets: List[Tuple[int, int]] = []
+    if mode == "current":
+        targets = [(now.year, now.month)]
+    elif mode == "manual" and isinstance(selected, list):
+        for raw in selected:
+            if not isinstance(raw, str) or "-" not in raw:
+                continue
+            y, m = raw.split("-", 1)
+            try:
+                year = int(y)
+                month = int(m)
+            except ValueError:
+                continue
+            if 1 <= month <= 12:
+                targets.append((year, month))
+    else:
+        for offset in range(months_count):
+            total = now.year * 12 + (now.month - 1) - offset
+            targets.append((total // 12, total % 12 + 1))
+
+    uniq = []
+    seen = set()
+    for year, month in targets:
+        key = f"{year}-{month:02d}"
+        if key in seen:
+            continue
+        seen.add(key)
+        month_path = os.path.join(root, str(year), _month_label(year, month))
+        uniq.append((year, month, month_path))
+    return uniq
+
+
+def _check_pdf_for_folder(order_path: str, folder_name: str) -> Tuple[bool, str]:
+    try:
+        st = os.stat(order_path)
+        dir_mtime = float(st.st_mtime)
+    except OSError:
+        return False, ""
+
+    candidates = _build_pdf_candidates(folder_name)
+    cache_key = os.path.normcase(os.path.abspath(order_path))
+    with _state_lock:
+        cache = (_state.get("pdf_cache") or {}).get(cache_key)
+
+    if isinstance(cache, dict) and float(cache.get("dir_mtime") or 0.0) == dir_mtime:
+        return bool(cache.get("has_pdf")), str(cache.get("pdf_name") or "")
+
+    has_pdf = False
+    matched = ""
+    candidate_set = {name.casefold() for name in candidates}
+    try:
+        with os.scandir(order_path) as it:
+            for entry in it:
+                if not entry.is_file():
+                    continue
+                if not entry.name.lower().endswith(".pdf"):
+                    continue
+                if entry.name.casefold() in candidate_set:
+                    has_pdf = True
+                    matched = entry.name
+                    break
+    except OSError:
+        has_pdf = False
+
+    with _state_lock:
+        _state.setdefault("pdf_cache", {})[cache_key] = {
+            "dir_mtime": dir_mtime,
+            "has_pdf": has_pdf,
+            "pdf_name": matched,
+            "checked_at": int(time.time()),
+        }
+    return has_pdf, matched
+
+
+def _can_mutate(order: dict, role: str, username: str) -> bool:
+    if role in {"admin", "technologist"}:
+        return True
+    if role == "manager":
+        return (order.get("owner_manager") or "") == (username or "")
+    return False
+
+
+def scan_cpu_orders(force: bool = False) -> dict:
+    global _last_scan_ts
+    if not force and (time.time() - _last_scan_ts) < _SCAN_TTL:
+        return get_cpu_payload()
+
+    if not _scan_lock.acquire(blocking=False):
+        return get_cpu_payload()
+
+    try:
+        root = app_config.DESENE_CPU_ROOT or ""
+        if not root or not os.path.isdir(root):
+            return get_cpu_payload()
+
+        with _state_lock:
+            orders = dict(_state.get("orders") or {})
+
+        seen_keys = set()
+        for year, month, month_path in _iter_month_paths(root):
+            if not os.path.isdir(month_path):
+                continue
+            try:
+                with os.scandir(month_path) as it:
+                    for entry in it:
+                        if not entry.is_dir():
+                            continue
+                        folder_name = entry.name
+                        order_path = os.path.join(month_path, folder_name)
+                        order_key = _extract_order_key(folder_name)
+                        has_pdf, pdf_name = _check_pdf_for_folder(order_path, folder_name)
+                        existing = orders.get(order_key) or {}
+                        status = existing.get("status") or "новый"
+                        if status == "подтвержден" and not has_pdf:
+                            # архив подтверждений не теряем
+                            pass
+                        elif not has_pdf and status == "новый":
+                            # новый без PDF не показываем
+                            continue
+
+                        if existing and existing.get("path") and existing.get("path") != order_path:
+                            log_order_event(
+                                "cpu_path_changed",
+                                order_name=folder_name,
+                                old_value=existing.get("path") or "",
+                                new_value=order_path,
+                            )
+
+                        updated = {
+                            "order_key": order_key,
+                            "folder_name": folder_name,
+                            "path": order_path,
+                            "year": year,
+                            "month": month,
+                            "month_label": _month_label(year, month),
+                            "status": status,
+                            "owner_manager": _resolve_owner_manager(folder_name, order_key),
+                            "has_pdf": has_pdf,
+                            "pdf_name": pdf_name,
+                            "updated_at": int(time.time()),
+                            "last_action_ts": int(existing.get("last_action_ts") or 0),
+                            "send_count": int(existing.get("send_count") or 0),
+                        }
+                        orders[order_key] = updated
+                        seen_keys.add(order_key)
+            except OSError:
+                continue
+
+        with _state_lock:
+            # не удаляем архивные/проверяемые записи из state
+            for key, item in list(orders.items()):
+                if key in seen_keys:
+                    continue
+                if (item.get("status") or "") == "новый":
+                    item["has_pdf"] = False
+                    orders[key] = item
+            _state["orders"] = orders
+            _state["updated_at"] = int(time.time())
+
+        _save_state()
+        _last_scan_ts = time.time()
+        return get_cpu_payload()
+    finally:
+        _scan_lock.release()
+
+
+def get_cpu_payload() -> dict:
+    with _state_lock:
+        orders = list((_state.get("orders") or {}).values())
+
+    active = [
+        item
+        for item in orders
+        if (item.get("status") in {"новый", "на проверке"}) and (item.get("has_pdf") or item.get("status") != "новый")
+    ]
+    active.sort(key=lambda x: ((x.get("status") != "новый"), -(x.get("updated_at") or 0)))
+
+    archive = [
+        item
+        for item in orders
+        if item.get("status") in {"на проверке", "подтвержден"}
+    ]
+    archive.sort(key=lambda x: -(x.get("last_action_ts") or x.get("updated_at") or 0))
+
+    grouped: Dict[str, Dict[str, List[dict]]] = {}
+    for item in archive:
+        year_key = str(item.get("year") or "—")
+        month_key = item.get("month_label") or "—"
+        grouped.setdefault(year_key, {})
+        grouped[year_key].setdefault(month_key, [])
+        grouped[year_key][month_key].append(item)
+
+    return {"active": active, "archive": archive, "archive_grouped": grouped, "updated_at": int(time.time())}
+
+
+def assign_manager(order_key: str, manager_name: str, user: str = "") -> Optional[dict]:
+    with _state_lock:
+        orders = _state.setdefault("orders", {})
+        item = orders.get(order_key)
+        if not item:
+            return None
+        _state.setdefault("manager_overrides", {})[order_key] = manager_name
+        item["owner_manager"] = manager_name
+        item["updated_at"] = int(time.time())
+        orders[order_key] = item
+    _save_state()
+    log_order_event(
+        "cpu_manager_override",
+        order_name=item.get("folder_name") or order_key,
+        old_value="",
+        new_value=manager_name,
+        user=user or None,
+    )
+    return item
+
+
+def send_to_customer(order_key: str, role: str, username: str) -> Tuple[bool, str, Optional[dict]]:
+    with _state_lock:
+        item = (_state.get("orders") or {}).get(order_key)
+        if not item:
+            return False, "Заказ не найден.", None
+        if not _can_mutate(item, role, username):
+            return False, "Недостаточно прав для этого заказа.", None
+        before = item.get("status") or "новый"
+        if before == "новый":
+            item["status"] = "на проверке"
+        item["send_count"] = int(item.get("send_count") or 0) + 1
+        item["last_action_ts"] = int(time.time())
+        item["updated_at"] = int(time.time())
+        _state["orders"][order_key] = item
+    _save_state()
+    log_order_event(
+        "cpu_send",
+        order_name=item.get("folder_name") or order_key,
+        manager=item.get("owner_manager") or "",
+        old_value=before,
+        new_value=item.get("status") or "",
+        user=username or None,
+    )
+    return True, "", item
+
+
+def confirm_order(order_key: str, role: str, username: str) -> Tuple[bool, str, Optional[dict]]:
+    with _state_lock:
+        item = (_state.get("orders") or {}).get(order_key)
+        if not item:
+            return False, "Заказ не найден.", None
+        if not _can_mutate(item, role, username):
+            return False, "Недостаточно прав для этого заказа.", None
+        before = item.get("status") or "новый"
+        item["status"] = "подтвержден"
+        item["last_action_ts"] = int(time.time())
+        item["updated_at"] = int(time.time())
+        _state["orders"][order_key] = item
+    _save_state()
+    log_order_event(
+        "cpu_confirm",
+        order_name=item.get("folder_name") or order_key,
+        manager=item.get("owner_manager") or "",
+        old_value=before,
+        new_value="подтвержден",
+        user=username or None,
+    )
+    return True, "", item
+
+
+_load_state()

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -1891,6 +1891,65 @@ window.setStatusFilter = OrdersPage.setStatusFilter;
 window.setManagerFilter = OrdersPage.setManagerFilter;
 window.sortBy = OrdersPage.sortBy;
 
+
+const CpuPage = (() => {
+  function init() {
+    const table = document.getElementById('cpuActiveTable');
+    if (!table) return;
+    table.addEventListener('click', onClick);
+  }
+
+  async function onClick(event) {
+    const row = event.target.closest('tr[data-order-key]');
+    if (!row) return;
+    const orderKey = row.dataset.orderKey;
+
+    if (event.target.matches('[data-cpu-send]')) {
+      await sendAction(orderKey, 'send');
+    }
+    if (event.target.matches('[data-cpu-confirm]')) {
+      await sendAction(orderKey, 'confirm');
+    }
+    if (event.target.matches('[data-cpu-manager]')) {
+      const manager = prompt('Введите менеджера');
+      if (!manager) return;
+      await postJson(`/api/cpu/${encodeURIComponent(orderKey)}/manager`, { manager });
+      window.location.reload();
+    }
+  }
+
+  async function sendAction(orderKey, action) {
+    const res = await postJson(`/api/cpu/${encodeURIComponent(orderKey)}/${action}`, {});
+    if (!res || res.status !== 'ok') {
+      alert(res?.message || 'Ошибка действия');
+      return;
+    }
+    if (action === 'send') {
+      const value = res.copy_path || '';
+      if (value && navigator.clipboard?.writeText) {
+        try {
+          await navigator.clipboard.writeText(value);
+        } catch (err) {
+          console.warn('Clipboard недоступен', err);
+        }
+      }
+    }
+    window.location.reload();
+  }
+
+  async function postJson(url, body) {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: withCsrfHeaders({ 'Content-Type': 'application/json' }),
+      body: JSON.stringify(withCsrfBody(body || {}))
+    });
+    return response.json().catch(() => ({}));
+  }
+
+  return { init };
+})();
+
+
 document.addEventListener('DOMContentLoaded', () => {
   OrdersPage.init();
   ClientsPage.init();
@@ -1900,6 +1959,7 @@ document.addEventListener('DOMContentLoaded', () => {
   SettingsPage.init();
   UsersTable.init();
   UIEffects.init();
+  CpuPage.init();
 });
 
 const ClientsTable = (() => {

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -2345,3 +2345,12 @@ code {
 .role-card--creation .role-card__footer .btn:active{
   transform: translateY(1px);
 }
+
+.checkbox-list {
+  display: grid;
+  gap: 8px;
+}
+
+.checkbox-list--columns {
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -27,6 +27,8 @@
   <div class="page {% block page_class %}page--wide{% endblock %}">
     <nav class="top-menu">
       <a href="/">📦 Мониторинг</a>
+      <a href="/cpu">🧠 DESENE CPU</a>
+      <a href="/cpu/archive">🗂 CPU Архив</a>
       {% if role_perms.can_access_clients %}
       <a href="/clients">👥 Клиенты</a>
       {% endif %}

--- a/app/templates/cpu_archive.html
+++ b/app/templates/cpu_archive.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+{% block title %}DESENE CPU Archive{% endblock %}
+{% block content %}
+<section class="card">
+  <h1 class="section-title">DESENE CPU Archive</h1>
+  <form method="get" class="controls-grid">
+    <input type="search" class="input" name="q" value="{{ query }}" placeholder="Поиск по номеру/клиенту/менеджеру/статусу">
+    <button type="submit" class="btn btn--ghost">Поиск</button>
+  </form>
+  {% for year, months in archive_grouped.items()|sort(reverse=True) %}
+    <h2 class="section-subtitle">{{ year }}</h2>
+    {% for month, items in months.items() %}
+      <h3>{{ month }}</h3>
+      <div class="table-scroll table-scroll--compact">
+      <table class="data-table data-table--compact">
+        <thead><tr><th>Заказ</th><th>Менеджер</th><th>Статус</th><th>Последнее действие</th></tr></thead>
+        <tbody>
+          {% for item in items %}
+          <tr>
+            <td>{{ item.folder_name }}</td>
+            <td>{{ item.owner_manager or 'Не назначен' }}</td>
+            <td><span class="status-pill {% if item.status == 'на проверке' %}status-pill--success{% else %}status-pill--neutral{% endif %}">{{ item.status }}</span></td>
+            <td>{{ item.last_action_ts or item.updated_at }}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+      </div>
+    {% endfor %}
+  {% endfor %}
+</section>
+{% endblock %}

--- a/app/templates/cpu_monitor.html
+++ b/app/templates/cpu_monitor.html
@@ -1,0 +1,30 @@
+{% extends "base.html" %}
+{% block title %}DESENE CPU Monitor{% endblock %}
+{% block body_attrs %}data-page="cpu-monitor" data-managers='{{ managers|tojson }}'{% endblock %}
+{% block content %}
+<section class="card">
+  <h1 class="section-title">DESENE CPU Monitor — Активные</h1>
+  <div class="table-scroll">
+    <table class="data-table" id="cpuActiveTable">
+      <thead><tr><th>Заказ</th><th>Менеджер</th><th>Статус</th><th>PDF</th><th>Действия</th></tr></thead>
+      <tbody>
+      {% for item in cpu_data.active %}
+      <tr data-order-key="{{ item.order_key }}">
+        <td>{{ item.folder_name }}</td>
+        <td>{{ item.owner_manager or 'Не назначен' }}</td>
+        <td>
+          <span class="status-pill {% if item.status == 'новый' %}status-pill--warning{% elif item.status == 'на проверке' %}status-pill--success{% else %}status-pill--neutral{% endif %}">{{ item.status }}</span>
+        </td>
+        <td>{{ item.pdf_name or ('PDF исчез' if not item.has_pdf else '') }}</td>
+        <td>
+          <button type="button" class="btn btn--ghost btn--compact" data-cpu-send>Отправить</button>
+          <button type="button" class="btn btn--secondary btn--compact" data-cpu-confirm>Подтвердил</button>
+          <button type="button" class="btn btn--ghost btn--compact" data-cpu-manager>Изменить менеджера</button>
+        </td>
+      </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</section>
+{% endblock %}

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -93,6 +93,48 @@ data-managers='{{ config_managers | tojson }}'
           <input type="text" class="input" id="facades_dir" name="facades_dir" placeholder="\\\\SERVER\\facades" value="{{ config.get('paths', {}).get('facades_dir', '') }}">
         </div>
 
+
+
+        <div class="settings-field settings-field--wide">
+          <label class="field-label" for="desene_cpu_root">DESENE CPU root</label>
+          <input type="text" class="input" id="desene_cpu_root" name="desene_cpu_root" placeholder="\\SERVER\homag\DESENE CPU" value="{{ config.get('paths', {}).get('desene_cpu_root', '') }}">
+        </div>
+
+        <div class="settings-field">
+          <label class="field-label" for="desene_cpu_scan_mode">DESENE CPU: режим сканирования месяцев</label>
+          {% set cpu_cfg = config.get('desene_cpu', {}) %}
+          <select class="select" id="desene_cpu_scan_mode" name="desene_cpu_scan_mode">
+            <option value="current" {% if cpu_cfg.get('scan_mode') == 'current' %}selected{% endif %}>Текущий месяц</option>
+            <option value="recent" {% if cpu_cfg.get('scan_mode', 'recent') == 'recent' %}selected{% endif %}>Последние N месяцев</option>
+            <option value="manual" {% if cpu_cfg.get('scan_mode') == 'manual' %}selected{% endif %}>Выбор вручную</option>
+          </select>
+        </div>
+
+        <div class="settings-field">
+          <label class="field-label" for="desene_cpu_scan_months">N месяцев (для режима "последние")</label>
+          <input type="number" class="input" id="desene_cpu_scan_months" name="desene_cpu_scan_months" min="1" max="12" value="{{ cpu_cfg.get('scan_months', 3) }}">
+        </div>
+
+        <div class="settings-field settings-field--wide">
+          <label class="field-label">DESENE CPU: месяцы вручную</label>
+          {% set selected_cpu_months = cpu_cfg.get('selected_months', []) %}
+          <div class="checkbox-list checkbox-list--columns">
+            {% for ym in cpu_month_choices %}
+            <label class="checkbox-row">
+              <input type="checkbox" name="desene_cpu_selected_months" value="{{ ym }}" {% if ym in selected_cpu_months %}checked{% endif %}>
+              <span>{{ ym }}</span>
+            </label>
+            {% endfor %}
+          </div>
+        </div>
+
+        <div class="settings-field settings-field--wide">
+          <label class="field-label" for="desene_cpu_manager_tags">DESENE CPU: теги менеджеров (tag=manager)</label>
+          <textarea id="desene_cpu_manager_tags" name="desene_cpu_manager_tags" class="input input--mono" placeholder="J=Кристина
+$=Игорь">{% for tag, manager in config.get('desene_cpu', {}).get('manager_tags', {}).items() %}{{ tag }}={{ manager }}
+{% endfor %}</textarea>
+        </div>
+
         <div class="settings-field settings-field--wide">
           <label class="field-label" for="search_folders">Папки для поиска (Название=Путь)</label>
           <textarea id="search_folders" name="search_folders" class="input input--mono" placeholder="Название=\\\\SERVER\\path">{{ search_text }}</textarea>


### PR DESCRIPTION
### Motivation
- Добавить отдельный поток мониторинга для папки `DESENE CPU`, который показывает в «Активных» только заказы с готовым PDF (готово к отправке менеджеру) без переписывания основного мониторинга.
- Обеспечить устойчивость к переименованиям (суффиксы `[X]`, множественные пробелы), кэширование проверки PDF и минимизировать подверстывание производительности при сканировании месяцев.
- Поддержать стандартный workflow: «новый» → «на проверке» → «подтвержден», с аудиторией действий и RBAC на backend.

### Description
- Добавлен новый сервис `app/services/cpu_monitor.py` реализующий: нормализацию `order_key`, правила поиска PDF (`CPU.pdf`, `{base}.pdf`, `{full_folder}.pdf`), ленивую проверку с кэшем по `dir_mtime`, сохранение состояния в `cpu_monitor_state.json` и логирование аудита (`cpu_send`, `cpu_confirm`, `cpu_manager_override`, `cpu_path_changed`).
- Добавлены маршруты и API в `app/routes/orders.py`: страницы `/cpu`, `/cpu/archive` и API `/api/cpu/data`, `/api/cpu/<order_key>/send`, `/api/cpu/<order_key>/confirm`, `/api/cpu/<order_key>/manager` с встраиваемой серверной проверкой прав на изменение (RBAC по роли/owner).
- Расширены настройки: `app/config.py` добавил секцию `desene_cpu` (scan mode, months, selected_months, manager_tags); `app/routes/settings.py` и `app/templates/settings.html` добавлены элементы управления режимом сканирования (current/recent/manual), выбор месяцев вручную и маппинг тегов менеджеров.
- UI и ассеты: добавлены шаблоны `app/templates/cpu_monitor.html` и `app/templates/cpu_archive.html`, пункт навигации в `app/templates/base.html`, клиентская логика в `app/static/script.js` (`CpuPage`) и минимальные стили в `app/static/style.css` для чекбокс-сетки; изменения не ломают существующие id/class.

### Testing
- Успешно скомпилированы изменённые модули: `python -m py_compile app/services/cpu_monitor.py app/routes/orders.py app/routes/settings.py app/config.py` (без ошибок).
- Автоматически поднято приложение и сделан скриншот страницы CPU мониторинга через headless Playwright (UI подгрузился и скриншот сохранён), подтверждая рендер страниц и подключение маршрутов.
- `pytest` запущен автоматически и вернул `no tests ran` (в репозитории нет unit-тестов на данный момент).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2d7d9b574832dbf6bb14f39655213)