### PR TITLE
Add DESENE CPU monitoring module with page, API, DB models and watcher

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -167,12 +167,14 @@ def register_blueprints(flask_app: Flask):
     from app.routes.clients import clients_bp
     from app.routes.orders import orders_bp
     from app.routes.settings import settings_bp
+    from app.routes.desene_cpu import desene_cpu_bp
 
     flask_app.register_blueprint(setup_bp)
     flask_app.register_blueprint(auth_bp)
     flask_app.register_blueprint(orders_bp)
     flask_app.register_blueprint(clients_bp)
     flask_app.register_blueprint(settings_bp)
+    flask_app.register_blueprint(desene_cpu_bp)
 
 
 def _attach_logger(flask_app: Flask) -> None:
@@ -209,6 +211,7 @@ def start_background_services():
     from app.services import orders_sync
     from app.services import snapshot as snapshot_service
     from app.services import telegram as telegram_service
+    from app.services import desene_cpu_monitor
 
     telegram_service.init_bot(app_config.TELEGRAM_TOKEN)
     telegram_service.load_messages_storage()
@@ -218,6 +221,7 @@ def start_background_services():
     snapshot_service.refresh_orders_snapshot(force=True)
     monitor_service.initialize_known_state()
     monitor_service.start_observer_once()
+    desene_cpu_monitor.start_once()
     orders_sync.start_sync_worker()
     orders_auto_confirm.start_auto_confirm_worker()
 

--- a/app/config.py
+++ b/app/config.py
@@ -24,6 +24,7 @@ DEFAULT_CONFIG = {
         "facades_dir": "",
         "prisadka_root": "",
         "desene_cpu_root": "",
+        "desene_cpu_scan": {"scan_mode": "last_n", "months_back": 2, "manual_months": []},
         "prisadka_client_root": "",
         "facades_list_dir": "",
         "search": {},
@@ -61,6 +62,9 @@ WATCHED_PATH = ""
 WATCHED_PATH_NORM = ""
 PRISADKA_ROOT = ""
 DESENE_CPU_ROOT = ""
+DESENE_CPU_SCAN_MODE = "last_n"
+DESENE_CPU_MONTHS_BACK = 2
+DESENE_CPU_MANUAL_MONTHS: list[str] = []
 PRISADKA_CLIENT_ROOT = ""
 FACADES_LIST_DIR = ""
 TELEGRAM_TOKEN = ""
@@ -223,6 +227,12 @@ def _parse_paths_config(value: dict) -> dict:
     facades_dir = str(value.get("facades_dir") or "").strip()
     prisadka_root = str(value.get("prisadka_root") or "").strip()
     desene_cpu_root = str(value.get("desene_cpu_root") or "").strip()
+    desene_cpu_scan = value.get("desene_cpu_scan") if isinstance(value.get("desene_cpu_scan"), dict) else {}
+    scan_mode = str(desene_cpu_scan.get("scan_mode") or "last_n").strip().lower()
+    if scan_mode not in {"current", "last_n", "manual"}:
+        scan_mode = "last_n"
+    months_back = max(1, min(24, _parse_int(desene_cpu_scan.get("months_back"), 2)))
+    manual_months = _parse_str_list(desene_cpu_scan.get("manual_months"))
     prisadka_client_root = str(value.get("prisadka_client_root") or "").strip()
     facades_list_dir = str(value.get("facades_list_dir") or "").strip()
     search_folders = _parse_search_folders(value.get("search"))
@@ -232,6 +242,7 @@ def _parse_paths_config(value: dict) -> dict:
         "facades_dir": facades_dir,
         "prisadka_root": prisadka_root,
         "desene_cpu_root": desene_cpu_root,
+        "desene_cpu_scan": {"scan_mode": scan_mode, "months_back": months_back, "manual_months": manual_months},
         "prisadka_client_root": prisadka_client_root,
         "facades_list_dir": facades_list_dir,
         "search": search_folders,
@@ -347,7 +358,8 @@ def apply_config(config):
 
     global CONFIG
     global FOLDER_PATH, FACADES_DIR, FACADES_FILE, WATCHED_PATH, WATCHED_PATH_NORM
-    global PRISADKA_ROOT, DESENE_CPU_ROOT, PRISADKA_CLIENT_ROOT, FACADES_LIST_DIR
+    global PRISADKA_ROOT, DESENE_CPU_ROOT, DESENE_CPU_SCAN_MODE, DESENE_CPU_MONTHS_BACK
+    global DESENE_CPU_MANUAL_MONTHS, PRISADKA_CLIENT_ROOT, FACADES_LIST_DIR
     global TELEGRAM_TOKEN, CHAT_ID, TELEGRAM_CHAT_IDS, SERVER_HOST, SERVER_PORT, DEBUG_MODE
     global SEARCH_FOLDERS, MANAGER_NAMES, TECHNOLOGIST_MARKERS, SEARCH_MONTHS
     global ORDER_CONFIRMATION_ENABLED, CONFIG_WARNINGS, LOG_RETENTION_DAYS, JOURNAL_RETENTION_DAYS
@@ -380,6 +392,12 @@ def apply_config(config):
     FACADES_DIR = paths.get("facades_dir") or ""
     PRISADKA_ROOT = paths.get("prisadka_root") or ""
     DESENE_CPU_ROOT = paths.get("desene_cpu_root") or ""
+    desene_cpu_scan = paths.get("desene_cpu_scan") or {}
+    DESENE_CPU_SCAN_MODE = str(desene_cpu_scan.get("scan_mode") or "last_n").strip().lower()
+    if DESENE_CPU_SCAN_MODE not in {"current", "last_n", "manual"}:
+        DESENE_CPU_SCAN_MODE = "last_n"
+    DESENE_CPU_MONTHS_BACK = max(1, _parse_int(desene_cpu_scan.get("months_back"), 2))
+    DESENE_CPU_MANUAL_MONTHS[:] = _parse_str_list(desene_cpu_scan.get("manual_months"))
     PRISADKA_CLIENT_ROOT = paths.get("prisadka_client_root") or ""
     FACADES_LIST_DIR = paths.get("facades_list_dir") or FACADES_DIR
     FACADES_FILE = (
@@ -499,6 +517,9 @@ __all__ = [
     "SEARCH_MONTHS",
     "PRISADKA_ROOT",
     "DESENE_CPU_ROOT",
+    "DESENE_CPU_SCAN_MODE",
+    "DESENE_CPU_MONTHS_BACK",
+    "DESENE_CPU_MANUAL_MONTHS",
     "PRISADKA_CLIENT_ROOT",
     "ORDER_CONFIRMATION_ENABLED",
     "ORDERS_PG_URL",

--- a/app/dal/db.py
+++ b/app/dal/db.py
@@ -230,6 +230,7 @@ def init_db() -> None:
     import app.dal.external_orders  # noqa: F401
     import app.dal.manager_priced  # noqa: F401
     import app.dal.order_manager_override  # noqa: F401
+    import app.dal.desene_cpu  # noqa: F401
 
     Base.metadata.create_all(engine)
     _ensure_role_permissions_columns()

--- a/app/dal/desene_cpu.py
+++ b/app/dal/desene_cpu.py
@@ -90,6 +90,49 @@ def log_action(order_id: int, action_type: str, actor_user: str, meta_json: str 
         )
 
 
+def rebind_order_path_by_code(
+    *,
+    month_key: str,
+    order_code: str,
+    new_folder_path: str,
+    new_folder_name: str,
+) -> Optional[DeseneCpuOrder]:
+    """Перепривязывает запись при rename/move папки, сохраняя статус и историю."""
+
+    norm_new = normalize_path(new_folder_path)
+    if not month_key or not order_code or not norm_new:
+        return None
+
+    with SessionLocal.begin() as session:
+        # Если новая папка уже есть в БД — переиспользовать её, ничего не делаем.
+        existing_new = session.execute(
+            select(DeseneCpuOrder).where(DeseneCpuOrder.normalized_path == norm_new)
+        ).scalar_one_or_none()
+        if existing_new:
+            return existing_new
+
+        candidates = session.execute(
+            select(DeseneCpuOrder)
+            .where(DeseneCpuOrder.month_key == month_key)
+            .where(DeseneCpuOrder.order_code == order_code)
+            .where(DeseneCpuOrder.normalized_path != norm_new)
+            .order_by(DeseneCpuOrder.updated_at.desc(), DeseneCpuOrder.id.desc())
+        ).scalars().all()
+
+        for row in candidates:
+            old_path = (row.folder_path or "").strip()
+            # Восстанавливаем связь только если старая папка реально исчезла.
+            if old_path and os.path.exists(old_path):
+                continue
+            row.normalized_path = norm_new
+            row.folder_path = new_folder_path
+            row.order_folder_name = new_folder_name
+            session.flush()
+            return row
+
+    return None
+
+
 def upsert_order(payload: Dict[str, Any]) -> DeseneCpuOrder:
     norm_path = normalize_path(payload.get("folder_path") or payload.get("normalized_path") or "")
     if not norm_path:

--- a/app/dal/desene_cpu.py
+++ b/app/dal/desene_cpu.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import os
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, String, Text, func, select
+
+from app.dal.db import Base, SessionLocal
+
+
+CPU_STATUS_NEW = "NEW"
+CPU_STATUS_IN_REVIEW = "IN_REVIEW"
+CPU_STATUS_CONFIRMED = "CONFIRMED"
+CPU_ARCHIVE_STATUSES = {CPU_STATUS_CONFIRMED}
+
+
+class DeseneCpuOrder(Base):
+    __tablename__ = "desene_cpu_orders"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    normalized_path = Column(String, unique=True, nullable=False, index=True)
+
+    year = Column(Integer, nullable=False, default=0)
+    month_folder = Column(String, nullable=False, default="")
+    month_key = Column(String, nullable=False, default="")
+
+    order_folder_name = Column(String, nullable=False, default="")
+    order_code = Column(String, nullable=False, default="")
+
+    manager_name = Column(String, nullable=False, default="Неизвестно")
+    status = Column(String, nullable=False, default=CPU_STATUS_NEW)
+
+    folder_path = Column(String, nullable=False, default="")
+    pdf_found = Column(Boolean, nullable=False, default=False)
+    pdf_path = Column(String, nullable=False, default="")
+    pdf_mtime = Column(DateTime(timezone=True), nullable=True)
+
+    folder_last_mtime_seen = Column(DateTime(timezone=True), nullable=True)
+    last_seen_ts = Column(DateTime(timezone=True), server_default=func.current_timestamp())
+    last_pdf_check_ts = Column(DateTime(timezone=True), nullable=True)
+
+    created_at = Column(DateTime(timezone=True), server_default=func.current_timestamp())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.current_timestamp())
+
+
+class DeseneCpuAction(Base):
+    __tablename__ = "desene_cpu_actions"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    order_id = Column(Integer, ForeignKey("desene_cpu_orders.id"), nullable=False, index=True)
+    action_type = Column(String, nullable=False)
+    actor_user = Column(String, nullable=False, default="system")
+    ts = Column(DateTime(timezone=True), server_default=func.current_timestamp())
+    meta_json = Column(Text, nullable=False, default="")
+
+
+def normalize_path(path: str) -> str:
+    raw = (path or "").strip()
+    if not raw:
+        return ""
+    # Нормализуем без изменения UNC-смысла, чтобы избежать дублей в БД.
+    return os.path.normcase(os.path.normpath(raw))
+
+
+def get_order(order_id: int) -> Optional[DeseneCpuOrder]:
+    with SessionLocal.begin() as session:
+        return session.get(DeseneCpuOrder, order_id)
+
+
+def get_order_by_path(path: str) -> Optional[DeseneCpuOrder]:
+    norm = normalize_path(path)
+    if not norm:
+        return None
+    with SessionLocal.begin() as session:
+        return session.execute(
+            select(DeseneCpuOrder).where(DeseneCpuOrder.normalized_path == norm)
+        ).scalar_one_or_none()
+
+
+def log_action(order_id: int, action_type: str, actor_user: str, meta_json: str = "") -> None:
+    with SessionLocal.begin() as session:
+        session.add(
+            DeseneCpuAction(
+                order_id=order_id,
+                action_type=action_type,
+                actor_user=(actor_user or "system"),
+                meta_json=meta_json or "",
+            )
+        )
+
+
+def upsert_order(payload: Dict[str, Any]) -> DeseneCpuOrder:
+    norm_path = normalize_path(payload.get("folder_path") or payload.get("normalized_path") or "")
+    if not norm_path:
+        raise ValueError("normalized path is required")
+
+    with SessionLocal.begin() as session:
+        row = session.execute(
+            select(DeseneCpuOrder).where(DeseneCpuOrder.normalized_path == norm_path)
+        ).scalar_one_or_none()
+        if row is None:
+            row = DeseneCpuOrder(normalized_path=norm_path)
+            session.add(row)
+
+        for field in (
+            "year",
+            "month_folder",
+            "month_key",
+            "order_folder_name",
+            "order_code",
+            "manager_name",
+            "status",
+            "folder_path",
+            "pdf_found",
+            "pdf_path",
+        ):
+            if field in payload:
+                setattr(row, field, payload.get(field))
+
+        if "pdf_mtime" in payload:
+            row.pdf_mtime = payload.get("pdf_mtime")
+        if "folder_last_mtime_seen" in payload:
+            row.folder_last_mtime_seen = payload.get("folder_last_mtime_seen")
+        if "last_seen_ts" in payload:
+            row.last_seen_ts = payload.get("last_seen_ts") or datetime.utcnow()
+        if "last_pdf_check_ts" in payload:
+            row.last_pdf_check_ts = payload.get("last_pdf_check_ts")
+
+        session.flush()
+        return row

--- a/app/routes/desene_cpu.py
+++ b/app/routes/desene_cpu.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import json
+
+from flask import Blueprint, g, jsonify, render_template, request, session
+from sqlalchemy import select
+
+import app.config as app_config
+from app.dal.db import SessionLocal
+from app.dal.desene_cpu import (
+    CPU_ARCHIVE_STATUSES,
+    CPU_STATUS_CONFIRMED,
+    CPU_STATUS_IN_REVIEW,
+    CPU_STATUS_NEW,
+    DeseneCpuAction,
+    DeseneCpuOrder,
+    log_action,
+)
+
+
+desene_cpu_bp = Blueprint("desene_cpu", __name__)
+
+
+def _can_access_order(order: DeseneCpuOrder) -> bool:
+    role = session.get("role") or ""
+    user = session.get("user") or ""
+    if role in {"admin", "technologist"}:
+        return True
+    if role == "manager":
+        return (order.manager_name or "") == user
+    return False
+
+
+@desene_cpu_bp.route("/desene_cpu")
+def desene_cpu_page():
+    return render_template("desene_cpu.html")
+
+
+@desene_cpu_bp.route("/api/desene_cpu/orders")
+def api_orders():
+    tab = (request.args.get("tab") or "active").strip().lower()
+    q = (request.args.get("q") or "").strip().lower()
+
+    with SessionLocal.begin() as session_db:
+        stmt = select(DeseneCpuOrder).where(DeseneCpuOrder.pdf_found == 1)
+        if tab == "archive":
+            stmt = stmt.where(DeseneCpuOrder.status.in_(CPU_ARCHIVE_STATUSES))
+        else:
+            stmt = stmt.where(DeseneCpuOrder.status.in_([CPU_STATUS_NEW, CPU_STATUS_IN_REVIEW]))
+
+        rows = session_db.execute(stmt).scalars().all()
+
+    prepared = []
+    for row in rows:
+        if not _can_access_order(row):
+            continue
+        item = {
+            "id": row.id,
+            "order_folder_name": row.order_folder_name,
+            "manager_name": row.manager_name,
+            "status": row.status,
+            "folder_path": row.folder_path,
+            "month_folder": row.month_folder,
+            "year": row.year,
+            "updated_at": row.updated_at.isoformat() if row.updated_at else "",
+        }
+        if q and q not in (row.order_folder_name or "").lower() and q not in (row.month_folder or "").lower():
+            continue
+        prepared.append(item)
+
+    prepared.sort(key=lambda x: (x.get("year") or 0, x.get("month_folder") or "", x.get("order_folder_name") or ""), reverse=True)
+    return jsonify({"status": "ok", "orders": prepared})
+
+
+@desene_cpu_bp.route("/api/desene_cpu/orders/<int:order_id>/send", methods=["POST"])
+def api_send(order_id: int):
+    user = session.get("user") or ""
+    with SessionLocal.begin() as session_db:
+        row = session_db.get(DeseneCpuOrder, order_id)
+        if not row:
+            return jsonify({"status": "error", "message": "Заказ не найден"}), 404
+        if not _can_access_order(row):
+            return jsonify({"status": "error", "message": "Нет прав"}), 403
+
+        if row.status == CPU_STATUS_NEW:
+            row.status = CPU_STATUS_IN_REVIEW
+            log_action(row.id, "SEND_TO_REVIEW", user, json.dumps({"from": CPU_STATUS_NEW, "to": CPU_STATUS_IN_REVIEW}, ensure_ascii=False))
+        else:
+            log_action(row.id, "SEND_TO_REVIEW", user)
+
+        folder_path = row.folder_path
+
+    return jsonify({"status": "ok", "folder_path": folder_path, "new_status": CPU_STATUS_IN_REVIEW})
+
+
+@desene_cpu_bp.route("/api/desene_cpu/orders/<int:order_id>/confirm", methods=["POST"])
+def api_confirm(order_id: int):
+    user = session.get("user") or ""
+    with SessionLocal.begin() as session_db:
+        row = session_db.get(DeseneCpuOrder, order_id)
+        if not row:
+            return jsonify({"status": "error", "message": "Заказ не найден"}), 404
+        if not _can_access_order(row):
+            return jsonify({"status": "error", "message": "Нет прав"}), 403
+        old = row.status
+        row.status = CPU_STATUS_CONFIRMED
+        log_action(row.id, "CONFIRM", user, json.dumps({"from": old, "to": CPU_STATUS_CONFIRMED}, ensure_ascii=False))
+
+    return jsonify({"status": "ok", "new_status": CPU_STATUS_CONFIRMED})
+
+
+@desene_cpu_bp.route("/api/desene_cpu/orders/<int:order_id>/set_manager", methods=["POST"])
+def api_set_manager(order_id: int):
+    payload = request.get_json(silent=True) or {}
+    manager_name = (payload.get("manager_name") or "").strip()
+    if not manager_name:
+        return jsonify({"status": "error", "message": "Менеджер не указан"}), 400
+    user = session.get("user") or ""
+
+    with SessionLocal.begin() as session_db:
+        row = session_db.get(DeseneCpuOrder, order_id)
+        if not row:
+            return jsonify({"status": "error", "message": "Заказ не найден"}), 404
+
+        role = session.get("role") or ""
+        if role not in {"admin", "technologist"}:
+            return jsonify({"status": "error", "message": "Нет прав"}), 403
+
+        old = row.manager_name
+        row.manager_name = manager_name
+        log_action(row.id, "MANAGER_CHANGED", user, json.dumps({"from": old, "to": manager_name}, ensure_ascii=False))
+
+    return jsonify({"status": "ok"})
+
+
+@desene_cpu_bp.route("/api/desene_cpu/orders/<int:order_id>/actions")
+def api_actions(order_id: int):
+    with SessionLocal.begin() as session_db:
+        row = session_db.get(DeseneCpuOrder, order_id)
+        if not row:
+            return jsonify({"status": "error", "message": "Заказ не найден"}), 404
+        if not _can_access_order(row):
+            return jsonify({"status": "error", "message": "Нет прав"}), 403
+
+        actions = session_db.execute(
+            select(DeseneCpuAction).where(DeseneCpuAction.order_id == order_id).order_by(DeseneCpuAction.ts.desc()).limit(100)
+        ).scalars().all()
+
+    return jsonify({
+        "status": "ok",
+        "actions": [
+            {
+                "action_type": a.action_type,
+                "actor_user": a.actor_user,
+                "ts": a.ts.isoformat() if a.ts else "",
+                "meta_json": a.meta_json,
+            }
+            for a in actions
+        ],
+        "managers": app_config.MANAGER_NAMES,
+    })

--- a/app/routes/settings.py
+++ b/app/routes/settings.py
@@ -133,6 +133,16 @@ def settings_page():
             facades_dir = request.form.get("facades_dir", "").strip()
             prisadka_root = request.form.get("prisadka_root", "").strip()
             desene_cpu_root = request.form.get("desene_cpu_root", "").strip()
+            desene_cpu_scan_mode = (request.form.get("desene_cpu_scan_mode", "last_n") or "last_n").strip().lower()
+            if desene_cpu_scan_mode not in {"current", "last_n", "manual"}:
+                desene_cpu_scan_mode = "last_n"
+            desene_cpu_months_back_raw = request.form.get("desene_cpu_months_back", "2").strip()
+            try:
+                desene_cpu_months_back = max(1, min(24, int(desene_cpu_months_back_raw or 2)))
+            except (TypeError, ValueError):
+                desene_cpu_months_back = 2
+                errors.append("DESENE CPU: количество месяцев должно быть числом.")
+            desene_cpu_manual_months = [item.strip() for item in (request.form.get("desene_cpu_manual_months", "") or "").splitlines() if item.strip()]
             prisadka_client_root = request.form.get("prisadka_client_root", "").strip()
             facades_list_dir = request.form.get("facades_list_dir", "").strip()
             search_raw = request.form.get("search_folders", "")
@@ -167,6 +177,11 @@ def settings_page():
                 paths_cfg["prisadka_root"] = prisadka_root
             if desene_cpu_root:
                 paths_cfg["desene_cpu_root"] = desene_cpu_root
+            paths_cfg["desene_cpu_scan"] = {
+                "scan_mode": desene_cpu_scan_mode,
+                "months_back": desene_cpu_months_back,
+                "manual_months": desene_cpu_manual_months,
+            }
             if prisadka_client_root:
                 paths_cfg["prisadka_client_root"] = prisadka_client_root
             if facades_list_dir:

--- a/app/services/desene_cpu_monitor.py
+++ b/app/services/desene_cpu_monitor.py
@@ -18,6 +18,7 @@ from app.dal.desene_cpu import (
     DeseneCpuOrder,
     log_action,
     normalize_path,
+    rebind_order_path_by_code,
     upsert_order,
 )
 
@@ -182,10 +183,25 @@ def _scan_folder(year: int, month_folder: str, folder_path: str) -> None:
 
     existing = None
     norm = normalize_path(folder_path)
+    folder_name = os.path.basename(folder_path)
+    month_key = f"{year}-{month_folder}"
+    order_code = _extract_order_code(folder_name)
+
+    # Сценарий rename: сохраняем статус/историю, меняем только path/name.
+    rebound = rebind_order_path_by_code(
+        month_key=month_key,
+        order_code=order_code,
+        new_folder_path=folder_path,
+        new_folder_name=folder_name,
+    )
     with SessionLocal.begin() as session:
         existing = session.execute(
             select(DeseneCpuOrder).where(DeseneCpuOrder.normalized_path == norm)
         ).scalar_one_or_none()
+        if existing is None and rebound is not None:
+            existing = session.execute(
+                select(DeseneCpuOrder).where(DeseneCpuOrder.normalized_path == norm)
+            ).scalar_one_or_none()
 
     should_check_pdf = True
     if existing and existing.folder_last_mtime_seen and existing.last_pdf_check_ts:
@@ -211,10 +227,10 @@ def _scan_folder(year: int, month_folder: str, folder_path: str) -> None:
     payload = {
         "year": year,
         "month_folder": month_folder,
-        "month_key": f"{year}-{month_folder}",
-        "order_folder_name": os.path.basename(folder_path),
-        "order_code": _extract_order_code(os.path.basename(folder_path)),
-        "manager_name": (existing.manager_name if existing and existing.manager_name else _extract_manager(os.path.basename(folder_path))) or "Неизвестно",
+        "month_key": month_key,
+        "order_folder_name": folder_name,
+        "order_code": order_code,
+        "manager_name": (existing.manager_name if existing and existing.manager_name else _extract_manager(folder_name)) or "Неизвестно",
         "status": existing.status if existing and existing.status else CPU_STATUS_NEW,
         "folder_path": folder_path,
         "pdf_found": bool(pdf_found),

--- a/app/services/desene_cpu_monitor.py
+++ b/app/services/desene_cpu_monitor.py
@@ -44,6 +44,7 @@ _lock = threading.Lock()
 _stop_event = threading.Event()
 _dirty_event = threading.Event()
 _observer: Observer | None = None
+PDF_RECHECK_SECONDS = 60
 
 
 def _month_folder(year: int, month: int) -> str:
@@ -177,7 +178,13 @@ def _scan_folder(year: int, month_folder: str, folder_path: str) -> None:
 
     should_check_pdf = True
     if existing and existing.folder_last_mtime_seen and existing.last_pdf_check_ts:
+        # В SMB/UNC mtime папки может не меняться при добавлении файла вглубь,
+        # поэтому для непройденных папок добавляем периодическую перепроверку.
         should_check_pdf = folder_mtime > existing.folder_last_mtime_seen
+        if not should_check_pdf:
+            last_check_age = (now - existing.last_pdf_check_ts).total_seconds()
+            if not existing.pdf_found and last_check_age >= PDF_RECHECK_SECONDS:
+                should_check_pdf = True
 
     pdf_found = bool(existing.pdf_found) if existing else False
     pdf_path = existing.pdf_path if existing else ""

--- a/app/services/desene_cpu_monitor.py
+++ b/app/services/desene_cpu_monitor.py
@@ -98,6 +98,43 @@ def _extract_manager(folder_name: str) -> str:
     return get_manager_from_name(folder_name)
 
 
+def _month_path_candidates(root: str, year: int, month_folder: str) -> list[str]:
+    """Строит кандидаты пути месяца с поддержкой root=...\DESENE CPU и root=...\DESENE CPU\<year>."""
+
+    root_clean = (root or "").strip()
+    if not root_clean:
+        return []
+
+    candidates = [
+        os.path.join(root_clean, str(year), month_folder),
+        os.path.join(root_clean, month_folder),
+    ]
+
+    base_name = os.path.basename(os.path.normpath(root_clean))
+    if base_name.isdigit() and len(base_name) == 4:
+        # Если root указывает на конкретный год, расширяем до родительского каталога.
+        parent = os.path.dirname(os.path.normpath(root_clean))
+        candidates.append(os.path.join(parent, str(year), month_folder))
+
+    # Дедупликация с сохранением порядка для предсказуемых логов.
+    unique: list[str] = []
+    seen = set()
+    for item in candidates:
+        norm = os.path.normcase(os.path.normpath(item))
+        if norm in seen:
+            continue
+        seen.add(norm)
+        unique.append(item)
+    return unique
+
+
+def _resolve_month_path(root: str, year: int, month_folder: str) -> str:
+    for candidate in _month_path_candidates(root, year, month_folder):
+        if os.path.isdir(candidate):
+            return candidate
+    return ""
+
+
 def _walk_pdf_candidates(folder_path: str, max_depth: int = 2):
     stack = [(folder_path, 0)]
     while stack:
@@ -180,9 +217,14 @@ def scan_once() -> None:
     seen: set[str] = set()
 
     for year, month_folder in targets:
-        month_path = os.path.join(root, str(year), month_folder)
-        if not os.path.isdir(month_path):
-            logger.warning("[desene_cpu] Папка месяца недоступна: %s", month_path)
+        month_path = _resolve_month_path(root, year, month_folder)
+        if not month_path:
+            logger.warning(
+                "[desene_cpu] Папка месяца недоступна: root=%s, year=%s, month=%s",
+                root,
+                year,
+                month_folder,
+            )
             continue
         try:
             with os.scandir(month_path) as it:

--- a/app/services/desene_cpu_monitor.py
+++ b/app/services/desene_cpu_monitor.py
@@ -47,6 +47,15 @@ _observer: Observer | None = None
 PDF_RECHECK_SECONDS = 60
 
 
+def _dt_to_ts(value: datetime | None) -> float | None:
+    """Безопасно приводит datetime из БД (aware/naive) к unix-ts."""
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc).timestamp()
+    return value.timestamp()
+
+
 def _month_folder(year: int, month: int) -> str:
     return f"{month:02d}. {_MONTHS_RO[month]} {year}"
 
@@ -167,7 +176,9 @@ def _find_matching_pdf(folder_path: str, folder_name: str) -> tuple[bool, str, d
 
 def _scan_folder(year: int, month_folder: str, folder_path: str) -> None:
     now = datetime.now(timezone.utc)
+    now_ts = now.timestamp()
     folder_mtime = datetime.fromtimestamp(os.path.getmtime(folder_path), tz=timezone.utc)
+    folder_mtime_ts = folder_mtime.timestamp()
 
     existing = None
     norm = normalize_path(folder_path)
@@ -180,9 +191,13 @@ def _scan_folder(year: int, month_folder: str, folder_path: str) -> None:
     if existing and existing.folder_last_mtime_seen and existing.last_pdf_check_ts:
         # В SMB/UNC mtime папки может не меняться при добавлении файла вглубь,
         # поэтому для непройденных папок добавляем периодическую перепроверку.
-        should_check_pdf = folder_mtime > existing.folder_last_mtime_seen
+        existing_folder_mtime_ts = _dt_to_ts(existing.folder_last_mtime_seen)
+        should_check_pdf = (
+            existing_folder_mtime_ts is None or folder_mtime_ts > existing_folder_mtime_ts
+        )
         if not should_check_pdf:
-            last_check_age = (now - existing.last_pdf_check_ts).total_seconds()
+            last_check_ts = _dt_to_ts(existing.last_pdf_check_ts)
+            last_check_age = (now_ts - last_check_ts) if last_check_ts is not None else PDF_RECHECK_SECONDS
             if not existing.pdf_found and last_check_age >= PDF_RECHECK_SECONDS:
                 should_check_pdf = True
 
@@ -239,7 +254,11 @@ def scan_once() -> None:
                     if not entry.is_dir():
                         continue
                     seen.add(normalize_path(entry.path))
-                    _scan_folder(year, month_folder, entry.path)
+                    try:
+                        _scan_folder(year, month_folder, entry.path)
+                    except Exception as exc:
+                        # Не прерываем весь проход из-за одной проблемной папки.
+                        logger.warning("[desene_cpu] Ошибка обработки папки %s", entry.path, exc_info=exc)
         except OSError as exc:
             logger.warning("[desene_cpu] Ошибка чтения %s", month_path, exc_info=exc)
 

--- a/app/services/desene_cpu_monitor.py
+++ b/app/services/desene_cpu_monitor.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+import os
+import re
+import threading
+import time
+from datetime import datetime, timezone
+
+from sqlalchemy import select
+from watchdog.events import FileSystemEventHandler
+from watchdog.observers import Observer
+
+import app.config as app_config
+from app import get_manager_from_name, logger
+from app.dal.db import SessionLocal
+from app.dal.desene_cpu import (
+    CPU_STATUS_NEW,
+    DeseneCpuOrder,
+    log_action,
+    normalize_path,
+    upsert_order,
+)
+
+_MONTHS_RO = {
+    1: "Ianuarie",
+    2: "Februarie",
+    3: "Martie",
+    4: "Aprilie",
+    5: "Mai",
+    6: "Iunie",
+    7: "Iulie",
+    8: "August",
+    9: "Septembrie",
+    10: "Octombrie",
+    11: "Noiembrie",
+    12: "Decembrie",
+}
+
+_code_re = re.compile(r"^(\d+-\d+)")
+_suffix_re = re.compile(r"\[([A-Za-zА-Яа-я])\]")
+
+_started = False
+_lock = threading.Lock()
+_stop_event = threading.Event()
+_dirty_event = threading.Event()
+_observer: Observer | None = None
+
+
+def _month_folder(year: int, month: int) -> str:
+    return f"{month:02d}. {_MONTHS_RO[month]} {year}"
+
+
+def _shift_months(year: int, month: int, delta: int) -> tuple[int, int]:
+    for _ in range(delta):
+        month -= 1
+        if month <= 0:
+            month = 12
+            year -= 1
+    return year, month
+
+
+def build_target_months(now: datetime | None = None) -> list[tuple[int, str]]:
+    now = now or datetime.now()
+    mode = app_config.DESENE_CPU_SCAN_MODE
+    if mode == "manual":
+        result: list[tuple[int, str]] = []
+        for item in app_config.DESENE_CPU_MANUAL_MONTHS:
+            text = (item or "").strip()
+            match = re.search(r"(\d{4})$", text)
+            if not text or not match:
+                continue
+            result.append((int(match.group(1)), text))
+        return result
+
+    if mode == "current":
+        return [(now.year, _month_folder(now.year, now.month))]
+
+    months_back = max(1, int(app_config.DESENE_CPU_MONTHS_BACK or 2))
+    values: list[tuple[int, str]] = []
+    for i in range(months_back):
+        y, m = _shift_months(now.year, now.month, i)
+        values.append((y, _month_folder(y, m)))
+    return values
+
+
+def _extract_order_code(name: str) -> str:
+    match = _code_re.match(name or "")
+    return match.group(1) if match else ""
+
+
+def _extract_manager(folder_name: str) -> str:
+    suffix_match = _suffix_re.search(folder_name or "")
+    if suffix_match:
+        marker = suffix_match.group(1).lower()
+        for manager in app_config.MANAGER_NAMES:
+            if manager and manager[0].lower() == marker:
+                return manager
+    return get_manager_from_name(folder_name)
+
+
+def _walk_pdf_candidates(folder_path: str, max_depth: int = 2):
+    stack = [(folder_path, 0)]
+    while stack:
+        current, depth = stack.pop()
+        try:
+            with os.scandir(current) as it:
+                for entry in it:
+                    if entry.is_file() and entry.name.lower().endswith(".pdf"):
+                        yield entry.path
+                    elif entry.is_dir() and depth < max_depth:
+                        stack.append((entry.path, depth + 1))
+        except OSError:
+            continue
+
+
+def _find_matching_pdf(folder_path: str, folder_name: str) -> tuple[bool, str, datetime | None]:
+    folder_pdf = f"{folder_name}.pdf".lower()
+    order_code = _extract_order_code(folder_name).lower()
+    for pdf_path in _walk_pdf_candidates(folder_path, max_depth=2):
+        base = os.path.basename(pdf_path).lower()
+        if base == "cpu.pdf" or base == folder_pdf or (order_code and base.startswith(order_code)):
+            try:
+                ts = os.path.getmtime(pdf_path)
+                return True, pdf_path, datetime.fromtimestamp(ts, tz=timezone.utc)
+            except OSError:
+                return True, pdf_path, None
+    return False, "", None
+
+
+def _scan_folder(year: int, month_folder: str, folder_path: str) -> None:
+    now = datetime.now(timezone.utc)
+    folder_mtime = datetime.fromtimestamp(os.path.getmtime(folder_path), tz=timezone.utc)
+
+    existing = None
+    norm = normalize_path(folder_path)
+    with SessionLocal.begin() as session:
+        existing = session.execute(
+            select(DeseneCpuOrder).where(DeseneCpuOrder.normalized_path == norm)
+        ).scalar_one_or_none()
+
+    should_check_pdf = True
+    if existing and existing.folder_last_mtime_seen and existing.last_pdf_check_ts:
+        should_check_pdf = folder_mtime > existing.folder_last_mtime_seen
+
+    pdf_found = bool(existing.pdf_found) if existing else False
+    pdf_path = existing.pdf_path if existing else ""
+    pdf_mtime = existing.pdf_mtime if existing else None
+
+    if should_check_pdf:
+        pdf_found, pdf_path, pdf_mtime = _find_matching_pdf(folder_path, os.path.basename(folder_path))
+
+    payload = {
+        "year": year,
+        "month_folder": month_folder,
+        "month_key": f"{year}-{month_folder}",
+        "order_folder_name": os.path.basename(folder_path),
+        "order_code": _extract_order_code(os.path.basename(folder_path)),
+        "manager_name": (existing.manager_name if existing and existing.manager_name else _extract_manager(os.path.basename(folder_path))) or "Неизвестно",
+        "status": existing.status if existing and existing.status else CPU_STATUS_NEW,
+        "folder_path": folder_path,
+        "pdf_found": bool(pdf_found),
+        "pdf_path": pdf_path,
+        "pdf_mtime": pdf_mtime,
+        "folder_last_mtime_seen": folder_mtime,
+        "last_seen_ts": now,
+        "last_pdf_check_ts": now if should_check_pdf else (existing.last_pdf_check_ts if existing else now),
+    }
+    row = upsert_order(payload)
+    if pdf_found and (not existing or not existing.pdf_found):
+        log_action(row.id, "PDF_DETECTED", "system")
+
+
+def scan_once() -> None:
+    root = (app_config.DESENE_CPU_ROOT or "").strip()
+    if not root:
+        logger.warning("[desene_cpu] ROOT не настроен")
+        return
+
+    targets = build_target_months()
+    seen: set[str] = set()
+
+    for year, month_folder in targets:
+        month_path = os.path.join(root, str(year), month_folder)
+        if not os.path.isdir(month_path):
+            logger.warning("[desene_cpu] Папка месяца недоступна: %s", month_path)
+            continue
+        try:
+            with os.scandir(month_path) as it:
+                for entry in it:
+                    if not entry.is_dir():
+                        continue
+                    seen.add(normalize_path(entry.path))
+                    _scan_folder(year, month_folder, entry.path)
+        except OSError as exc:
+            logger.warning("[desene_cpu] Ошибка чтения %s", month_path, exc_info=exc)
+
+    target_keys = {f"{year}-{month}" for year, month in targets}
+    with SessionLocal.begin() as session:
+        rows = session.execute(select(DeseneCpuOrder).where(DeseneCpuOrder.month_key.in_(target_keys))).scalars().all()
+        for row in rows:
+            if row.normalized_path not in seen and not os.path.exists(row.folder_path or ""):
+                session.delete(row)
+
+
+def _rescan_loop() -> None:
+    while not _stop_event.is_set():
+        try:
+            scan_once()
+        except Exception as exc:
+            logger.warning("[desene_cpu] Ошибка rescan", exc_info=exc)
+        _dirty_event.clear()
+        _stop_event.wait(45)
+
+
+class _CpuEventHandler(FileSystemEventHandler):
+    def on_any_event(self, event):
+        _dirty_event.set()
+
+
+def _watchdog_loop() -> None:
+    global _observer
+    root = (app_config.DESENE_CPU_ROOT or "").strip()
+    if not root or not os.path.isdir(root):
+        logger.warning("[desene_cpu] Watchdog не запущен: root недоступен: %s", root)
+        return
+
+    try:
+        obs = Observer()
+        obs.schedule(_CpuEventHandler(), root, recursive=True)
+        obs.start()
+        _observer = obs
+        logger.info("[desene_cpu] Watchdog запущен: %s", root)
+        while not _stop_event.is_set():
+            _dirty_event.wait(10)
+            if _dirty_event.is_set():
+                try:
+                    scan_once()
+                except Exception as exc:
+                    logger.warning("[desene_cpu] Ошибка watchdog-scan", exc_info=exc)
+                _dirty_event.clear()
+    except Exception as exc:
+        logger.warning("[desene_cpu] Ошибка watchdog", exc_info=exc)
+    finally:
+        if _observer:
+            _observer.stop()
+            _observer.join(timeout=5)
+            _observer = None
+
+
+def start_once() -> None:
+    global _started
+    with _lock:
+        if _started:
+            return
+        _started = True
+    _stop_event.clear()
+    threading.Thread(target=_rescan_loop, daemon=True).start()
+    threading.Thread(target=_watchdog_loop, daemon=True).start()

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -1997,3 +1997,167 @@ const ClientsTable = (() => {
 document.addEventListener('DOMContentLoaded', () => {
   ClientsTable.init();
 });
+
+const DeseneCpuPage = (() => {
+  let tab = 'active';
+  let search = '';
+
+  function init() {
+    if (document.body?.dataset?.page !== 'desene-cpu') return;
+    bindTabs();
+    const searchInput = document.getElementById('cpuSearch');
+    if (searchInput) {
+      searchInput.addEventListener('input', () => {
+        search = searchInput.value.trim();
+        load();
+      });
+    }
+    load();
+  }
+
+  function bindTabs() {
+    document.querySelectorAll('[data-cpu-tab]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        tab = btn.dataset.cpuTab || 'active';
+        document.querySelectorAll('[data-cpu-tab]').forEach(node => node.classList.toggle('is-active', node === btn));
+        load();
+      });
+    });
+  }
+
+  function statusBadge(status) {
+    const map = {
+      NEW: ['новый', 'status-pill status-pill--warning'],
+      IN_REVIEW: ['на проверке', 'status-pill status-pill--success'],
+      CONFIRMED: ['подтвержден', 'status-pill status-pill--neutral']
+    };
+    return map[status] || [status || '—', 'status-pill status-pill--neutral'];
+  }
+
+  async function load() {
+    const params = new URLSearchParams({ tab, q: search });
+    const resp = await fetch(`/api/desene_cpu/orders?${params.toString()}`);
+    const data = await resp.json().catch(() => ({ orders: [] }));
+    render(Array.isArray(data.orders) ? data.orders : []);
+  }
+
+  function canEditManager() {
+    return APP_CONFIG.currentRole === 'admin' || APP_CONFIG.currentRole === 'technologist';
+  }
+
+  function render(items) {
+    const tbody = document.querySelector('#cpuTable tbody');
+    if (!tbody) return;
+    tbody.innerHTML = '';
+
+    let currentMonth = null;
+    for (const item of items) {
+      if (tab === "archive" && item.month_folder !== currentMonth) {
+        currentMonth = item.month_folder;
+        const group = document.createElement("tr");
+        group.innerHTML = `<td colspan="5" class="table-primary">${escapeHtml(currentMonth || "—")}</td>`;
+        tbody.appendChild(group);
+      }
+      const [label, cls] = statusBadge(item.status);
+      const tr = document.createElement('tr');
+      tr.innerHTML = `
+        <td>${escapeHtml(item.order_folder_name || '')}</td>
+        <td>${renderManager(item)}</td>
+        <td><span class="${cls}">${label}</span></td>
+        <td>${escapeHtml(item.month_folder || '')}</td>
+        <td>${renderActions(item)}</td>
+      `;
+      tbody.appendChild(tr);
+    }
+
+    bindRowActions();
+  }
+
+  function renderManager(item) {
+    if (!canEditManager()) return escapeHtml(item.manager_name || 'Неизвестно');
+    const options = (APP_CONFIG.managers || []).map(m => `<option value="${escapeAttr(m)}" ${m === item.manager_name ? 'selected' : ''}>${escapeHtml(m)}</option>`).join('');
+    return `<select class="select" data-cpu-manager="${item.id}">${options}</select>`;
+  }
+
+  function renderActions(item) {
+    const sendDisabled = tab === 'archive' ? 'disabled' : '';
+    const confirmDisabled = tab === 'archive' ? 'disabled' : '';
+    return `
+      <div class="button-group">
+        <button type="button" class="btn btn--ghost btn--small" data-cpu-send="${item.id}" data-cpu-path="${escapeAttr(item.folder_path || '')}" ${sendDisabled}>Отправить</button>
+        <button type="button" class="btn btn--secondary btn--small" data-cpu-confirm="${item.id}" ${confirmDisabled}>Подтвердил</button>
+      </div>
+    `;
+  }
+
+  function bindRowActions() {
+    document.querySelectorAll('[data-cpu-send]').forEach(btn => {
+      btn.addEventListener('click', async () => {
+        const id = btn.dataset.cpuSend;
+        const resp = await fetch(`/api/desene_cpu/orders/${id}/send`, {
+          method: 'POST',
+          headers: withCsrfHeaders({ 'Content-Type': 'application/json' }),
+          body: JSON.stringify(withCsrfBody({}))
+        });
+        const data = await resp.json().catch(() => ({}));
+        if (!resp.ok) {
+          alert(data.message || 'Ошибка');
+          return;
+        }
+        const path = data.folder_path || btn.dataset.cpuPath || '';
+        if (path) {
+          await navigator.clipboard.writeText(path).catch(() => {});
+        }
+        load();
+      });
+    });
+
+    document.querySelectorAll('[data-cpu-confirm]').forEach(btn => {
+      btn.addEventListener('click', async () => {
+        const id = btn.dataset.cpuConfirm;
+        const resp = await fetch(`/api/desene_cpu/orders/${id}/confirm`, {
+          method: 'POST',
+          headers: withCsrfHeaders({ 'Content-Type': 'application/json' }),
+          body: JSON.stringify(withCsrfBody({}))
+        });
+        const data = await resp.json().catch(() => ({}));
+        if (!resp.ok) {
+          alert(data.message || 'Ошибка');
+          return;
+        }
+        load();
+      });
+    });
+
+    document.querySelectorAll('[data-cpu-manager]').forEach(select => {
+      select.addEventListener('change', async () => {
+        const id = select.dataset.cpuManager;
+        const manager_name = select.value;
+        const resp = await fetch(`/api/desene_cpu/orders/${id}/set_manager`, {
+          method: 'POST',
+          headers: withCsrfHeaders({ 'Content-Type': 'application/json' }),
+          body: JSON.stringify(withCsrfBody({ manager_name }))
+        });
+        if (!resp.ok) {
+          const data = await resp.json().catch(() => ({}));
+          alert(data.message || 'Ошибка смены менеджера');
+          load();
+        }
+      });
+    });
+  }
+
+  function escapeHtml(v) {
+    return `${v || ''}`.replace(/[&<>"']/g, s => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[s]));
+  }
+
+  function escapeAttr(v) {
+    return escapeHtml(v);
+  }
+
+  return { init };
+})();
+
+document.addEventListener('DOMContentLoaded', () => {
+  DeseneCpuPage.init();
+});

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -2127,6 +2127,36 @@ const DeseneCpuPage = (() => {
     currentItems = currentItems.map(item => (Number(item.id) === Number(id) ? { ...item, ...patch } : item));
   }
 
+  async function copyCpuFolderPath(text, trigger) {
+    if (!text) return false;
+
+    const fallbackCopy = () => {
+      const area = document.createElement('textarea');
+      area.value = text;
+      document.body.appendChild(area);
+      area.select();
+      document.execCommand('copy');
+      document.body.removeChild(area);
+    };
+
+    try {
+      if (navigator?.clipboard?.writeText) {
+        await navigator.clipboard.writeText(text);
+      } else {
+        fallbackCopy();
+      }
+    } catch (err) {
+      // Clipboard API может быть ограничен политиками браузера/контекста.
+      fallbackCopy();
+    }
+
+    if (trigger) {
+      trigger.classList.add('flash-highlight');
+      setTimeout(() => trigger.classList.remove('flash-highlight'), 900);
+    }
+    return true;
+  }
+
   function bindRowActions() {
     document.querySelectorAll('[data-cpu-send]').forEach(btn => {
       btn.addEventListener('click', async () => {
@@ -2143,7 +2173,10 @@ const DeseneCpuPage = (() => {
         }
         const path = data.folder_path || btn.dataset.cpuPath || '';
         if (path) {
-          await copyTextPayload(path, btn);
+          const copied = await copyCpuFolderPath(path, btn);
+          if (!copied) {
+            alert('Не удалось скопировать путь к папке');
+          }
         } else {
           alert('Путь к папке не найден для копирования');
         }

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -2001,6 +2001,7 @@ document.addEventListener('DOMContentLoaded', () => {
 const DeseneCpuPage = (() => {
   let tab = 'active';
   let search = '';
+  let currentItems = [];
 
   function init() {
     if (document.body?.dataset?.page !== 'desene-cpu') return;
@@ -2013,6 +2014,12 @@ const DeseneCpuPage = (() => {
       });
     }
     load();
+    // Лёгкий polling только для этой страницы: чтобы новые PDF появлялись без ручного refresh.
+    window.setInterval(() => {
+      if (document.body?.dataset?.page === 'desene-cpu') {
+        load();
+      }
+    }, 10000);
   }
 
   function bindTabs() {
@@ -2034,11 +2041,19 @@ const DeseneCpuPage = (() => {
     return map[status] || [status || '—', 'status-pill status-pill--neutral'];
   }
 
+  function statusRowClass(status) {
+    if (status === 'NEW') return 'new';
+    if (status === 'IN_REVIEW') return 'done';
+    if (status === 'CONFIRMED') return 'confirmed';
+    return '';
+  }
+
   async function load() {
     const params = new URLSearchParams({ tab, q: search });
     const resp = await fetch(`/api/desene_cpu/orders?${params.toString()}`);
     const data = await resp.json().catch(() => ({ orders: [] }));
-    render(Array.isArray(data.orders) ? data.orders : []);
+    currentItems = Array.isArray(data.orders) ? data.orders : [];
+    render(currentItems);
   }
 
   function canEditManager() {
@@ -2052,14 +2067,17 @@ const DeseneCpuPage = (() => {
 
     let currentMonth = null;
     for (const item of items) {
-      if (tab === "archive" && item.month_folder !== currentMonth) {
+      if (tab === 'archive' && item.month_folder !== currentMonth) {
         currentMonth = item.month_folder;
-        const group = document.createElement("tr");
-        group.innerHTML = `<td colspan="5" class="table-primary">${escapeHtml(currentMonth || "—")}</td>`;
+        const group = document.createElement('tr');
+        group.innerHTML = `<td colspan="5" class="table-primary">${escapeHtml(currentMonth || '—')}</td>`;
         tbody.appendChild(group);
       }
       const [label, cls] = statusBadge(item.status);
       const tr = document.createElement('tr');
+      const rowCls = statusRowClass(item.status);
+      if (rowCls) tr.classList.add(rowCls);
+      tr.dataset.cpuOrderId = `${item.id}`;
       tr.innerHTML = `
         <td>${escapeHtml(item.order_folder_name || '')}</td>
         <td>${renderManager(item)}</td>
@@ -2074,9 +2092,24 @@ const DeseneCpuPage = (() => {
   }
 
   function renderManager(item) {
-    if (!canEditManager()) return escapeHtml(item.manager_name || 'Неизвестно');
-    const options = (APP_CONFIG.managers || []).map(m => `<option value="${escapeAttr(m)}" ${m === item.manager_name ? 'selected' : ''}>${escapeHtml(m)}</option>`).join('');
-    return `<select class="select" data-cpu-manager="${item.id}">${options}</select>`;
+    const manager = escapeHtml(item.manager_name || 'Неизвестно');
+    if (!canEditManager()) return manager;
+
+    const options = (APP_CONFIG.managers || [])
+      .map(m => `<option value="${escapeAttr(m)}" ${m === item.manager_name ? 'selected' : ''}>${escapeHtml(m)}</option>`)
+      .join('');
+
+    return `
+      <div class="cpu-manager-cell" data-cpu-manager-cell="${item.id}">
+        <span class="cpu-manager-value" data-cpu-manager-value="${item.id}">${manager}</span>
+        <button type="button" class="btn btn--ghost btn--small" data-cpu-manager-edit="${item.id}" title="Изменить менеджера">✏️</button>
+        <div class="cpu-manager-editor is-hidden" data-cpu-manager-editor="${item.id}">
+          <select class="select" data-cpu-manager-select="${item.id}">${options}</select>
+          <button type="button" class="btn btn--primary btn--small" data-cpu-manager-save="${item.id}">OK</button>
+          <button type="button" class="btn btn--ghost btn--small" data-cpu-manager-cancel="${item.id}">✖</button>
+        </div>
+      </div>
+    `;
   }
 
   function renderActions(item) {
@@ -2090,10 +2123,14 @@ const DeseneCpuPage = (() => {
     `;
   }
 
+  function patchItem(id, patch) {
+    currentItems = currentItems.map(item => (Number(item.id) === Number(id) ? { ...item, ...patch } : item));
+  }
+
   function bindRowActions() {
     document.querySelectorAll('[data-cpu-send]').forEach(btn => {
       btn.addEventListener('click', async () => {
-        const id = btn.dataset.cpuSend;
+        const id = Number(btn.dataset.cpuSend || 0);
         const resp = await fetch(`/api/desene_cpu/orders/${id}/send`, {
           method: 'POST',
           headers: withCsrfHeaders({ 'Content-Type': 'application/json' }),
@@ -2108,13 +2145,15 @@ const DeseneCpuPage = (() => {
         if (path) {
           await navigator.clipboard.writeText(path).catch(() => {});
         }
-        load();
+        // Мгновенное обновление статуса в UI без перезагрузки.
+        patchItem(id, { status: 'IN_REVIEW' });
+        render(currentItems);
       });
     });
 
     document.querySelectorAll('[data-cpu-confirm]').forEach(btn => {
       btn.addEventListener('click', async () => {
-        const id = btn.dataset.cpuConfirm;
+        const id = Number(btn.dataset.cpuConfirm || 0);
         const resp = await fetch(`/api/desene_cpu/orders/${id}/confirm`, {
           method: 'POST',
           headers: withCsrfHeaders({ 'Content-Type': 'application/json' }),
@@ -2125,13 +2164,38 @@ const DeseneCpuPage = (() => {
           alert(data.message || 'Ошибка');
           return;
         }
-        load();
+        if (tab === 'active') {
+          currentItems = currentItems.filter(item => Number(item.id) !== id);
+        } else {
+          patchItem(id, { status: 'CONFIRMED' });
+        }
+        render(currentItems);
       });
     });
 
-    document.querySelectorAll('[data-cpu-manager]').forEach(select => {
-      select.addEventListener('change', async () => {
-        const id = select.dataset.cpuManager;
+    document.querySelectorAll('[data-cpu-manager-edit]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const id = btn.dataset.cpuManagerEdit;
+        const editor = document.querySelector(`[data-cpu-manager-editor="${id}"]`);
+        if (!editor) return;
+        editor.classList.remove('is-hidden');
+      });
+    });
+
+    document.querySelectorAll('[data-cpu-manager-cancel]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const id = btn.dataset.cpuManagerCancel;
+        const editor = document.querySelector(`[data-cpu-manager-editor="${id}"]`);
+        if (!editor) return;
+        editor.classList.add('is-hidden');
+      });
+    });
+
+    document.querySelectorAll('[data-cpu-manager-save]').forEach(btn => {
+      btn.addEventListener('click', async () => {
+        const id = Number(btn.dataset.cpuManagerSave || 0);
+        const select = document.querySelector(`[data-cpu-manager-select="${id}"]`);
+        if (!select) return;
         const manager_name = select.value;
         const resp = await fetch(`/api/desene_cpu/orders/${id}/set_manager`, {
           method: 'POST',
@@ -2141,8 +2205,10 @@ const DeseneCpuPage = (() => {
         if (!resp.ok) {
           const data = await resp.json().catch(() => ({}));
           alert(data.message || 'Ошибка смены менеджера');
-          load();
+          return;
         }
+        patchItem(id, { manager_name });
+        render(currentItems);
       });
     });
   }

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -2143,7 +2143,9 @@ const DeseneCpuPage = (() => {
         }
         const path = data.folder_path || btn.dataset.cpuPath || '';
         if (path) {
-          await navigator.clipboard.writeText(path).catch(() => {});
+          await copyTextPayload(path, btn);
+        } else {
+          alert('Путь к папке не найден для копирования');
         }
         // Мгновенное обновление статуса в UI без перезагрузки.
         patchItem(id, { status: 'IN_REVIEW' });

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -2345,3 +2345,20 @@ code {
 .role-card--creation .role-card__footer .btn:active{
   transform: translateY(1px);
 }
+
+/* DESENE CPU manager inline editor */
+.cpu-manager-cell {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.cpu-manager-editor {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.cpu-manager-editor.is-hidden {
+  display: none;
+}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -27,6 +27,7 @@
   <div class="page {% block page_class %}page--wide{% endblock %}">
     <nav class="top-menu">
       <a href="/">📦 Мониторинг</a>
+      <a href="/desene_cpu">🧠 Desene CPU</a>
       {% if role_perms.can_access_clients %}
       <a href="/clients">👥 Клиенты</a>
       {% endif %}

--- a/app/templates/desene_cpu.html
+++ b/app/templates/desene_cpu.html
@@ -1,0 +1,45 @@
+{% extends "base.html" %}
+
+{% block title %}Мониторинг Desene CPU{% endblock %}
+
+{% block body_attrs %}
+data-page="desene-cpu"
+data-managers='{{ config_managers | tojson }}'
+{% endblock %}
+
+{% block content %}
+<header class="page-header">
+  <h1>🧠 Мониторинг Desene CPU</h1>
+  <p class="page-description">Актуальные и архивные CPU-заказы на основе найденных PDF.</p>
+</header>
+
+<section class="card controls-card">
+  <div class="tabs">
+    <button type="button" class="tab-btn is-active" data-cpu-tab="active">Актуальные</button>
+    <button type="button" class="tab-btn" data-cpu-tab="archive">Архив</button>
+  </div>
+  <div class="controls-grid">
+    <div class="filter-search">
+      <label class="field-label" for="cpuSearch">Поиск</label>
+      <input type="search" id="cpuSearch" class="input input--compact search-grow" placeholder="Заказ или месяц">
+    </div>
+  </div>
+</section>
+
+<section class="card table-card">
+  <div class="table-scroll">
+    <table class="data-table" id="cpuTable">
+      <thead>
+      <tr>
+        <th>Заказ</th>
+        <th>Менеджер</th>
+        <th>Статус</th>
+        <th>Месяц</th>
+        <th>Действия</th>
+      </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </div>
+</section>
+{% endblock %}

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -94,6 +94,31 @@ data-managers='{{ config_managers | tojson }}'
         </div>
 
         <div class="settings-field settings-field--wide">
+          <label class="field-label" for="desene_cpu_root">DESENE CPU ROOT</label>
+          <input type="text" class="input" id="desene_cpu_root" name="desene_cpu_root" placeholder="\\SERVER\homag\DESENE CPU" value="{{ config.get('paths', {}).get('desene_cpu_root', '') }}">
+        </div>
+
+        {% set cpu_scan = config.get('paths', {}).get('desene_cpu_scan', {}) %}
+        <div class="settings-field">
+          <label class="field-label" for="desene_cpu_scan_mode">DESENE CPU scan mode</label>
+          <select id="desene_cpu_scan_mode" name="desene_cpu_scan_mode" class="select">
+            <option value="current" {% if cpu_scan.get('scan_mode') == 'current' %}selected{% endif %}>current</option>
+            <option value="last_n" {% if cpu_scan.get('scan_mode', 'last_n') == 'last_n' %}selected{% endif %}>last_n</option>
+            <option value="manual" {% if cpu_scan.get('scan_mode') == 'manual' %}selected{% endif %}>manual</option>
+          </select>
+        </div>
+
+        <div class="settings-field">
+          <label class="field-label" for="desene_cpu_months_back">DESENE CPU N месяцев</label>
+          <input type="number" class="input" id="desene_cpu_months_back" name="desene_cpu_months_back" min="1" max="24" value="{{ cpu_scan.get('months_back', 2) }}">
+        </div>
+
+        <div class="settings-field settings-field--wide">
+          <label class="field-label" for="desene_cpu_manual_months">DESENE CPU manual_months (по одному в строке)</label>
+          <textarea id="desene_cpu_manual_months" name="desene_cpu_manual_months" class="input" placeholder="02. Februarie 2026">{{ "\n".join(cpu_scan.get('manual_months', [])) }}</textarea>
+        </div>
+
+        <div class="settings-field settings-field--wide">
           <label class="field-label" for="search_folders">Папки для поиска (Название=Путь)</label>
           <textarea id="search_folders" name="search_folders" class="input input--mono" placeholder="Название=\\\\SERVER\\path">{{ search_text }}</textarea>
           <p class="hint">Используйте по одному пути в строке: <code>Название=\\\\server\\share</code>.</p>


### PR DESCRIPTION
### Motivation
- Add a separate Desene CPU monitoring view and workflow that shows only order folders where a CPU PDF was detected and reuses existing project patterns (DB layer, roles, UI). 
- Preserve the existing monitoring core and reuse its patterns (watchdog, settings, DB, UI components) while providing an independent workflow (NEW → IN_REVIEW → CONFIRMED).

### Description
- New DB models and DAL: added `desene_cpu_orders` and `desene_cpu_actions` with fields for normalized path, year/month, manager, status, pdf metadata and timestamps in `app/dal/desene_cpu.py` and registered import in `app/dal/db.py` so tables are created on `init_db()`.
- Background scanner/watchdog: new service `app/services/desene_cpu_monitor.py` implements month-scope calculation (`current|last_n|manual`), lazy PDF detection (rules: `cpu.pdf`, `<folder>.pdf`, or filename starting with order code), limited depth walk, rescan loop and watchdog events, and upserts orders into DB.
- Routes and API: new blueprint `app/routes/desene_cpu.py` with page `GET /desene_cpu` and APIs `GET /api/desene_cpu/orders`, `POST /api/desene_cpu/orders/<id>/send`, `POST /api/desene_cpu/orders/<id>/confirm`, `POST /api/desene_cpu/orders/<id>/set_manager`, `GET /api/desene_cpu/orders/<id>/actions` with server-side permission checks (manager vs technologist/admin) and action logging.
- UI and frontend: added `app/templates/desene_cpu.html`, menu link in `base.html`, and client logic in `app/static/script.js` to render Active/Archive tabs, grouping in archive by month, search, manager editing, and actions (Send — copies folder path & logs, Confirm — archives, manager change).
- Settings integration: added `desene_cpu_root` and `desene_cpu_scan` config to `app/config.py`, settings inputs and form handling in `app/templates/settings.html` and `app/routes/settings.py` (scan_mode, months_back, manual_months), and safe defaults so scanning works from ROOT + selected months.
- Initialization wiring: register blueprint and start CPU background service in application startup (`app/__init__.py`) while keeping original background services intact.
- Non-invasive: kept project CSS/JS patterns, re-used existing DB/session patterns and audit logging without changing core monitoring behavior.

### Testing
- `python -m compileall app` — OK, all modules compiled successfully.
- Application create smoke attempt (`from app import create_app`) was not executed in a full runtime because `flask` is not available in the execution environment, so full runtime test was not possible (environment limitation).
- Attempted browser check via Playwright to load `http://localhost:5000/desene_cpu` failed because local server was not running in this environment (`ERR_EMPTY_RESPONSE`).
- Code changes committed and staged; commit message: "Add DESENE CPU monitoring module with workflow and settings".

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2dd518e98832d97c504b1124203e1)