### PR TITLE
Fix Desene CPU initial loading, manager visibility and per-manager stats

### DIFF
--- a/app/routes/desene_cpu.py
+++ b/app/routes/desene_cpu.py
@@ -144,14 +144,22 @@ def api_orders():
             continue
         filtered.append(item)
 
-    manager_stats_map: dict[str, int] = {}
+    # Держим стабильный набор менеджеров в статистике: конфиг + "Неизвестно".
+    manager_stats_map: dict[str, int] = {
+        name: 0 for name in [*app_config.MANAGER_NAMES, "Неизвестно"] if (name or "").strip()
+    }
     for item in stats_filtered:
         manager_name = (item.get("manager_name") or "Неизвестно").strip() or "Неизвестно"
         manager_stats_map[manager_name] = manager_stats_map.get(manager_name, 0) + 1
-    manager_stats = [
-        {"manager_name": name, "count": count}
-        for name, count in sorted(manager_stats_map.items(), key=lambda pair: (-pair[1], pair[0].lower()))
-    ]
+
+    configured_names = [name for name in [*app_config.MANAGER_NAMES, "Неизвестно"] if (name or "").strip()]
+    manager_stats = [{"manager_name": name, "count": manager_stats_map.get(name, 0)} for name in configured_names]
+
+    extra_names = sorted(
+        [name for name in manager_stats_map.keys() if name not in configured_names],
+        key=lambda value: value.lower(),
+    )
+    manager_stats.extend({"manager_name": name, "count": manager_stats_map[name]} for name in extra_names)
 
     # Сортируем по самой свежей дате (created_at, fallback updated_at), затем по id.
     filtered.sort(key=lambda x: (x.get("created_at") or x.get("updated_at") or "", x.get("id") or 0), reverse=True)

--- a/app/routes/desene_cpu.py
+++ b/app/routes/desene_cpu.py
@@ -7,6 +7,7 @@ from flask import Blueprint, g, jsonify, render_template, request, session
 from sqlalchemy import select
 
 import app.config as app_config
+from app import get_manager_from_name
 from app.dal.db import SessionLocal
 from app.dal.desene_cpu import (
     CPU_ARCHIVE_STATUSES,
@@ -22,12 +23,24 @@ from app.dal.desene_cpu import (
 desene_cpu_bp = Blueprint("desene_cpu", __name__)
 
 
-def _can_access_order(order: DeseneCpuOrder) -> bool:
+def _can_view_order(order: DeseneCpuOrder) -> bool:
     role = session.get("role") or ""
     user = session.get("user") or ""
     if role in {"admin", "technologist"}:
         return True
     if role == "manager":
+        # Менеджеры могут смотреть общий список и переключаться между менеджерами.
+        return True
+    return False
+
+
+def _can_mutate_order(order: DeseneCpuOrder) -> bool:
+    role = session.get("role") or ""
+    user = session.get("user") or ""
+    if role in {"admin", "technologist"}:
+        return True
+    if role == "manager":
+        # Изменять статус менеджер может только у собственных заказов.
         return (order.manager_name or "") == user
     return False
 
@@ -59,9 +72,15 @@ def api_orders():
 
         rows = session_db.execute(stmt).scalars().all()
 
+        for row in rows:
+            # Подтягиваем актуального менеджера из справочника клиентов.
+            mapped_manager = get_manager_from_name(row.order_folder_name or "")
+            if mapped_manager and mapped_manager != "Неизвестно" and (row.manager_name or "") != mapped_manager:
+                row.manager_name = mapped_manager
+
     prepared = []
     for row in rows:
-        if not _can_access_order(row):
+        if not _can_view_order(row):
             continue
         item = {
             "id": row.id,
@@ -76,6 +95,7 @@ def api_orders():
             "created_at": row.created_at.isoformat() if row.created_at else "",
             "reviewed_at": "",
             "confirmed_at": "",
+            "can_transition": _can_mutate_order(row),
         }
         if q and q not in (row.order_folder_name or "").lower() and q not in (row.month_folder or "").lower():
             continue
@@ -110,6 +130,7 @@ def api_orders():
     default_month = current_month_key if current_month_key in month_map else (months[0]["key"] if months else "")
 
     filtered = []
+    stats_filtered = []
     for item in prepared:
         action_state = action_map.get(item["id"], {})
         item["reviewed_at"] = action_state.get("reviewed_at") or ""
@@ -118,13 +139,29 @@ def api_orders():
             continue
         if status_filter != "ALL" and (item.get("status") or "") != status_filter:
             continue
+        stats_filtered.append(item)
         if manager_filter and manager_filter != "Все" and (item.get("manager_name") or "") != manager_filter:
             continue
         filtered.append(item)
 
+    manager_stats_map: dict[str, int] = {}
+    for item in stats_filtered:
+        manager_name = (item.get("manager_name") or "Неизвестно").strip() or "Неизвестно"
+        manager_stats_map[manager_name] = manager_stats_map.get(manager_name, 0) + 1
+    manager_stats = [
+        {"manager_name": name, "count": count}
+        for name, count in sorted(manager_stats_map.items(), key=lambda pair: (-pair[1], pair[0].lower()))
+    ]
+
     # Сортируем по самой свежей дате (created_at, fallback updated_at), затем по id.
     filtered.sort(key=lambda x: (x.get("created_at") or x.get("updated_at") or "", x.get("id") or 0), reverse=True)
-    return jsonify({"status": "ok", "orders": filtered, "months": months, "default_month": default_month})
+    return jsonify({
+        "status": "ok",
+        "orders": filtered,
+        "months": months,
+        "default_month": default_month,
+        "manager_stats": manager_stats,
+    })
 
 
 @desene_cpu_bp.route("/api/desene_cpu/orders/<int:order_id>/send", methods=["POST"])
@@ -136,7 +173,7 @@ def api_send(order_id: int):
         row = session_db.get(DeseneCpuOrder, order_id)
         if not row:
             return jsonify({"status": "error", "message": "Заказ не найден"}), 404
-        if not _can_access_order(row):
+        if not _can_mutate_order(row):
             return jsonify({"status": "error", "message": "Нет прав"}), 403
 
         if row.status == CPU_STATUS_NEW:
@@ -159,7 +196,7 @@ def api_confirm(order_id: int):
         row = session_db.get(DeseneCpuOrder, order_id)
         if not row:
             return jsonify({"status": "error", "message": "Заказ не найден"}), 404
-        if not _can_access_order(row):
+        if not _can_mutate_order(row):
             return jsonify({"status": "error", "message": "Нет прав"}), 403
         old = row.status
         row.status = CPU_STATUS_CONFIRMED
@@ -202,7 +239,7 @@ def api_actions(order_id: int):
         row = session_db.get(DeseneCpuOrder, order_id)
         if not row:
             return jsonify({"status": "error", "message": "Заказ не найден"}), 404
-        if not _can_access_order(row):
+        if not _can_view_order(row):
             return jsonify({"status": "error", "message": "Нет прав"}), 403
 
         actions = session_db.execute(

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -2123,28 +2123,45 @@ const DeseneCpuPage = (() => {
     const months = Array.isArray(data?.months) ? data.months : [];
     const currentMonth = getCurrentMonthKey();
 
-    // Для текущего месяца используем исходный label из API (если есть), чтобы сохранить формат вида "03. Martie 2026".
-    const currentMonthFromApi = months.find(item => `${item?.key || ''}`.trim() === currentMonth);
+    const normalizeMonthKey = value => {
+      const raw = `${value || ''}`.trim();
+      const match = raw.match(/^(\d{4})-(\d{1,2})$/);
+      if (!match) return raw;
+      return `${match[1]}-${String(Number(match[2])).padStart(2, '0')}`;
+    };
 
-    // Текущий месяц всегда в начале списка, даже если по нему пока нет записей.
-    const preparedMonths = [];
+    // Не создаём искусственные месяцы: используем только те, что пришли из API/сетевых папок.
+    const currentNorm = normalizeMonthKey(currentMonth);
     const seen = new Set();
-    preparedMonths.push({
-      key: currentMonth,
-      label: (currentMonthFromApi?.label || '').trim() || formatMonthLabel(currentMonth)
-    });
-    seen.add(currentMonth);
+    const preparedMonths = [];
+    const restMonths = [];
 
     for (const item of months) {
-      const key = `${item?.key || ''}`.trim();
-      if (!key || seen.has(key)) continue;
-      preparedMonths.push(item);
-      seen.add(key);
+      const rawKey = `${item?.key || ''}`.trim();
+      const normKey = normalizeMonthKey(rawKey);
+      if (!normKey || seen.has(normKey)) continue;
+      seen.add(normKey);
+
+      const normalizedItem = {
+        key: normKey,
+        label: `${item?.label || ''}`.trim() || formatMonthLabel(normKey)
+      };
+      if (normKey === currentNorm) {
+        preparedMonths.push(normalizedItem);
+      } else {
+        restMonths.push(normalizedItem);
+      }
     }
 
-    if (month && !seen.has(month)) {
-      // Сохраняем выбранный месяц в селекте, чтобы фильтр не "прыгал".
-      preparedMonths.push({ key: month, label: formatMonthLabel(month) });
+    preparedMonths.push(...restMonths);
+
+    const monthNorm = normalizeMonthKey(month);
+    if (monthNorm && seen.has(monthNorm)) {
+      month = monthNorm;
+    } else if (data?.default_month) {
+      month = normalizeMonthKey(data.default_month);
+    } else {
+      month = '';
     }
 
     const options = [`<option value="">Все месяцы</option>`]

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -2012,7 +2012,6 @@ const DeseneCpuPage = (() => {
   let month = getCurrentMonthKey();
   let manager = 'Все';
   let currentItems = [];
-  let isMonthHydrating = false;
 
   function init() {
     if (document.body?.dataset?.page !== 'desene-cpu') return;
@@ -2069,8 +2068,9 @@ const DeseneCpuPage = (() => {
     const managerSelect = document.getElementById('cpuManagerFilter');
     if (!managerSelect) return;
     const managers = Array.isArray(APP_CONFIG.managers) ? APP_CONFIG.managers : [];
+    const uniqueManagers = Array.from(new Set(managers.concat(['Неизвестно'])));
     managerSelect.innerHTML = ['<option value="Все">Все</option>']
-      .concat(managers.map(name => `<option value="${escapeAttr(name)}">${escapeHtml(name)}</option>`))
+      .concat(uniqueManagers.map(name => `<option value="${escapeAttr(name)}">${escapeHtml(name)}</option>`))
       .join('');
     managerSelect.value = manager;
     managerSelect.addEventListener('change', () => {
@@ -2111,17 +2111,7 @@ const DeseneCpuPage = (() => {
     if (manager && manager !== 'Все') params.set('manager', manager);
     const resp = await fetch(`/api/desene_cpu/orders?${params.toString()}`);
     const data = await resp.json().catch(() => ({ orders: [] }));
-    const monthChanged = hydrateMonthSelect(data);
-    if (monthChanged && !isMonthHydrating) {
-      // Месяц автоматически скорректирован, перезапрашиваем данные один раз.
-      isMonthHydrating = true;
-      try {
-        await load();
-      } finally {
-        isMonthHydrating = false;
-      }
-      return;
-    }
+    hydrateMonthSelect(data);
     renderStats(data.orders || [], data.manager_stats || []);
     currentItems = Array.isArray(data.orders) ? data.orders : [];
     render(currentItems);
@@ -2129,18 +2119,32 @@ const DeseneCpuPage = (() => {
 
   function hydrateMonthSelect(data) {
     const monthSelect = document.getElementById('cpuMonthFilter');
-    if (!monthSelect) return false;
+    if (!monthSelect) return;
     const months = Array.isArray(data?.months) ? data.months : [];
-    const monthKeys = new Set(months.map(item => item?.key).filter(Boolean));
-    const prevMonth = month;
-    if (month && !monthKeys.has(month)) {
-      month = data?.default_month || '';
+    const currentMonth = getCurrentMonthKey();
+
+    // Текущий месяц всегда в начале списка, даже если по нему пока нет записей.
+    const preparedMonths = [];
+    const seen = new Set();
+    preparedMonths.push({ key: currentMonth, label: formatMonthLabel(currentMonth) });
+    seen.add(currentMonth);
+
+    for (const item of months) {
+      const key = `${item?.key || ''}`.trim();
+      if (!key || seen.has(key)) continue;
+      preparedMonths.push(item);
+      seen.add(key);
     }
+
+    if (month && !seen.has(month)) {
+      // Сохраняем выбранный месяц в селекте, чтобы фильтр не "прыгал".
+      preparedMonths.push({ key: month, label: formatMonthLabel(month) });
+    }
+
     const options = [`<option value="">Все месяцы</option>`]
-      .concat(months.map(item => `<option value="${escapeAttr(item.key)}">${escapeHtml(item.label)}</option>`));
+      .concat(preparedMonths.map(item => `<option value="${escapeAttr(item.key)}">${escapeHtml(item.label)}</option>`));
     monthSelect.innerHTML = options.join('');
     monthSelect.value = month;
-    return prevMonth !== month;
   }
 
   function renderStats(items, managerStats) {
@@ -2149,35 +2153,27 @@ const DeseneCpuPage = (() => {
     const rows = Array.isArray(items) ? items : [];
     const total = rows.length;
     const statsRows = Array.isArray(managerStats) ? managerStats : [];
-    const statsTable = statsRows.length
-      ? `
-        <div class="table-scroll">
-          <table class="data-table">
-            <thead>
-              <tr>
-                <th>Менеджер</th>
-                <th>Заказов</th>
-              </tr>
-            </thead>
-            <tbody>
-              ${statsRows.map(item => `
-                <tr>
-                  <td>${escapeHtml(item.manager_name || 'Неизвестно')}</td>
-                  <td>${Number(item.count || 0)}</td>
-                </tr>
-              `).join('')}
-            </tbody>
-          </table>
-        </div>
-      `
+
+    const managerItems = statsRows.length
+      ? statsRows.map(item => `
+          <div class="cpu-manager-stat">
+            <span class="cpu-manager-stat__name">${escapeHtml(item.manager_name || 'Неизвестно')}</span>
+            <span class="cpu-manager-stat__count">${Number(item.count || 0)}</span>
+          </div>
+        `).join('')
       : '<p class="table-primary">Нет данных по менеджерам для выбранного периода.</p>';
 
     el.innerHTML = `
-      <article class="stat-card">
-        <span class="stat-label">Всего заказов</span>
-        <span class="stat-value stat-value--compact">${total}</span>
-      </article>
-      ${statsTable}
+      <div class="cpu-stats-grid">
+        <article class="stat-card cpu-stat-card">
+          <span class="stat-label">Всего заказов</span>
+          <span class="stat-value stat-value--compact">${total}</span>
+        </article>
+        <article class="stat-card cpu-stat-card">
+          <span class="stat-label">Менеджеры</span>
+          <div class="cpu-manager-stats-grid">${managerItems}</div>
+        </article>
+      </div>
     `;
   }
 
@@ -2241,7 +2237,8 @@ const DeseneCpuPage = (() => {
     const manager = escapeHtml(item.manager_name || 'Неизвестно');
     if (!canEditManager()) return manager;
 
-    const options = (APP_CONFIG.managers || [])
+    const managerOptions = Array.from(new Set([...(APP_CONFIG.managers || []), 'Неизвестно']));
+    const options = managerOptions
       .map(m => `<option value="${escapeAttr(m)}" ${m === item.manager_name ? 'selected' : ''}>${escapeHtml(m)}</option>`)
       .join('');
 

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -2193,7 +2193,23 @@ const DeseneCpuPage = (() => {
     const raw = `${monthKey || ''}`.trim();
     if (!raw || !/^\d{4}-\d{2}$/.test(raw)) return 'текущий месяц';
     const [year, monthNum] = raw.split('-');
-    return `${monthNum}.${year}`;
+    const monthNamesRo = {
+      '01': 'Ianuarie',
+      '02': 'Februarie',
+      '03': 'Martie',
+      '04': 'Aprilie',
+      '05': 'Mai',
+      '06': 'Iunie',
+      '07': 'Iulie',
+      '08': 'August',
+      '09': 'Septembrie',
+      '10': 'Octombrie',
+      '11': 'Noiembrie',
+      '12': 'Decembrie'
+    };
+    // Формат фиксированный: MM. <RomanianMonth> YYYY. Меняется только год/номер месяца.
+    const monthName = monthNamesRo[monthNum] || monthNum;
+    return `${monthNum}. ${monthName} ${year}`;
   }
 
   function canEditManager() {

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -2005,6 +2005,13 @@ const DeseneCpuPage = (() => {
     return `${now.getFullYear()}-${monthNum}`;
   }
 
+  function normalizeMonthKey(value) {
+    const raw = `${value || ''}`.trim();
+    const match = raw.match(/^(\d{4})-(\d{1,2})$/);
+    if (!match) return raw;
+    return `${match[1]}-${String(Number(match[2])).padStart(2, '0')}`;
+  }
+
   let tab = 'active';
   let search = '';
   let status = 'all';
@@ -2012,6 +2019,7 @@ const DeseneCpuPage = (() => {
   let month = getCurrentMonthKey();
   let manager = 'Все';
   let currentItems = [];
+  let isAutoMonthReloading = false;
 
   function init() {
     if (document.body?.dataset?.page !== 'desene-cpu') return;
@@ -2106,12 +2114,25 @@ const DeseneCpuPage = (() => {
   }
 
   async function load() {
+    const requestedMonth = normalizeMonthKey(month);
     const params = new URLSearchParams({ tab, q: search, status });
     if (month) params.set('month', month);
     if (manager && manager !== 'Все') params.set('manager', manager);
     const resp = await fetch(`/api/desene_cpu/orders?${params.toString()}`);
     const data = await resp.json().catch(() => ({ orders: [] }));
     hydrateMonthSelect(data);
+
+    if (!isAutoMonthReloading && requestedMonth !== normalizeMonthKey(month)) {
+      // После автокоррекции месяца делаем один догружающий запрос для корректного списка заказов.
+      isAutoMonthReloading = true;
+      try {
+        await load();
+      } finally {
+        isAutoMonthReloading = false;
+      }
+      return;
+    }
+
     renderStats(data.orders || [], data.manager_stats || []);
     currentItems = Array.isArray(data.orders) ? data.orders : [];
     render(currentItems);
@@ -2122,13 +2143,6 @@ const DeseneCpuPage = (() => {
     if (!monthSelect) return;
     const months = Array.isArray(data?.months) ? data.months : [];
     const currentMonth = getCurrentMonthKey();
-
-    const normalizeMonthKey = value => {
-      const raw = `${value || ''}`.trim();
-      const match = raw.match(/^(\d{4})-(\d{1,2})$/);
-      if (!match) return raw;
-      return `${match[1]}-${String(Number(match[2])).padStart(2, '0')}`;
-    };
 
     // Не создаём искусственные месяцы: используем только те, что пришли из API/сетевых папок.
     const currentNorm = normalizeMonthKey(currentMonth);

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -2123,10 +2123,16 @@ const DeseneCpuPage = (() => {
     const months = Array.isArray(data?.months) ? data.months : [];
     const currentMonth = getCurrentMonthKey();
 
+    // Для текущего месяца используем исходный label из API (если есть), чтобы сохранить формат вида "03. Martie 2026".
+    const currentMonthFromApi = months.find(item => `${item?.key || ''}`.trim() === currentMonth);
+
     // Текущий месяц всегда в начале списка, даже если по нему пока нет записей.
     const preparedMonths = [];
     const seen = new Set();
-    preparedMonths.push({ key: currentMonth, label: formatMonthLabel(currentMonth) });
+    preparedMonths.push({
+      key: currentMonth,
+      label: (currentMonthFromApi?.label || '').trim() || formatMonthLabel(currentMonth)
+    });
     seen.add(currentMonth);
 
     for (const item of months) {

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -2012,6 +2012,7 @@ const DeseneCpuPage = (() => {
   let month = getCurrentMonthKey();
   let manager = 'Все';
   let currentItems = [];
+  let isMonthHydrating = false;
 
   function init() {
     if (document.body?.dataset?.page !== 'desene-cpu') return;
@@ -2110,17 +2111,28 @@ const DeseneCpuPage = (() => {
     if (manager && manager !== 'Все') params.set('manager', manager);
     const resp = await fetch(`/api/desene_cpu/orders?${params.toString()}`);
     const data = await resp.json().catch(() => ({ orders: [] }));
-    hydrateMonthSelect(data);
-    renderStats(data.orders || []);
+    const monthChanged = hydrateMonthSelect(data);
+    if (monthChanged && !isMonthHydrating) {
+      // Месяц автоматически скорректирован, перезапрашиваем данные один раз.
+      isMonthHydrating = true;
+      try {
+        await load();
+      } finally {
+        isMonthHydrating = false;
+      }
+      return;
+    }
+    renderStats(data.orders || [], data.manager_stats || []);
     currentItems = Array.isArray(data.orders) ? data.orders : [];
     render(currentItems);
   }
 
   function hydrateMonthSelect(data) {
     const monthSelect = document.getElementById('cpuMonthFilter');
-    if (!monthSelect) return;
+    if (!monthSelect) return false;
     const months = Array.isArray(data?.months) ? data.months : [];
     const monthKeys = new Set(months.map(item => item?.key).filter(Boolean));
+    const prevMonth = month;
     if (month && !monthKeys.has(month)) {
       month = data?.default_month || '';
     }
@@ -2128,18 +2140,44 @@ const DeseneCpuPage = (() => {
       .concat(months.map(item => `<option value="${escapeAttr(item.key)}">${escapeHtml(item.label)}</option>`));
     monthSelect.innerHTML = options.join('');
     monthSelect.value = month;
+    return prevMonth !== month;
   }
 
-  function renderStats(items) {
+  function renderStats(items, managerStats) {
     const el = document.getElementById('cpuStats');
     if (!el) return;
     const rows = Array.isArray(items) ? items : [];
     const total = rows.length;
+    const statsRows = Array.isArray(managerStats) ? managerStats : [];
+    const statsTable = statsRows.length
+      ? `
+        <div class="table-scroll">
+          <table class="data-table">
+            <thead>
+              <tr>
+                <th>Менеджер</th>
+                <th>Заказов</th>
+              </tr>
+            </thead>
+            <tbody>
+              ${statsRows.map(item => `
+                <tr>
+                  <td>${escapeHtml(item.manager_name || 'Неизвестно')}</td>
+                  <td>${Number(item.count || 0)}</td>
+                </tr>
+              `).join('')}
+            </tbody>
+          </table>
+        </div>
+      `
+      : '<p class="table-primary">Нет данных по менеджерам для выбранного периода.</p>';
+
     el.innerHTML = `
       <article class="stat-card">
         <span class="stat-label">Всего заказов</span>
         <span class="stat-value stat-value--compact">${total}</span>
       </article>
+      ${statsTable}
     `;
   }
 
@@ -2221,8 +2259,8 @@ const DeseneCpuPage = (() => {
   }
 
   function renderActions(item) {
-    const sendDisabled = tab === 'archive' ? 'disabled' : '';
-    const confirmDisabled = tab === 'archive' ? 'disabled' : '';
+    const sendDisabled = tab === 'archive' || !item?.can_transition ? 'disabled' : '';
+    const confirmDisabled = tab === 'archive' || !item?.can_transition ? 'disabled' : '';
     return `
       <div class="button-group">
         <button type="button" class="btn btn--ghost btn--small" data-cpu-send="${item.id}" data-cpu-path="${escapeAttr(item.folder_path || '')}" ${sendDisabled}>Отправить</button>

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -2346,6 +2346,46 @@ code {
   transform: translateY(1px);
 }
 
+
+/* DESENE CPU stats widgets */
+.cpu-stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 16px;
+  width: 100%;
+}
+
+.cpu-stat-card {
+  padding: 16px 18px;
+  gap: 10px;
+}
+
+.cpu-manager-stats-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(120px, 1fr));
+  gap: 8px;
+}
+
+.cpu-manager-stat {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.05);
+  padding: 8px 12px;
+}
+
+.cpu-manager-stat__name {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.cpu-manager-stat__count {
+  font-weight: 700;
+  color: var(--primary);
+}
+
 /* DESENE CPU manager inline editor */
 .cpu-manager-cell {
   display: inline-flex;


### PR DESCRIPTION
### Motivation
- Устранить проблему пустого экрана в `desene_cpu` при старте, когда текущий месяц отсутствует в данных. 
- Дать менеджерам возможность просматривать заказы других менеджеров для фильтра/аналитики, но запретить им менять статусы чужих заказов. 
- Обеспечить обновление имени менеджера в CPU-заказах после правок в клиентской базе. 
- Показать не только общее число заказов, но и агрегированную таблицу «Менеджер / Заказов». 

### Description
- Разделение прав доступа: добавлены `_can_view_order` и `_can_mutate_order` и применены в эндпоинтах `api_orders`, `api_send`, `api_confirm` и `api_actions` для корректного контроля просмотра и модификации. (файл `app/routes/desene_cpu.py`).
- При формировании списка заказов теперь подтягивается актуальный менеджер из справочника клиентов через `get_manager_from_name`, и это имя учитывается в выдаче списка. (файл `app/routes/desene_cpu.py`).
- API возвращает новое поле `can_transition` для каждой записи и агрегированное поле `manager_stats` — список объектов `{manager_name, count}` для построения таблицы по менеджерам. (файл `app/routes/desene_cpu.py`).
- На клиенте: реализован механизм «hydration» месяца с флагом `isMonthHydrating`, который автоматически корректирует месяц и повторно делает запрос один раз, чтобы избежать начального пустого состояния; добавлено отображение таблицы по менеджерам в `cpuStats`; действия `Отправить/Подтвердил` блокируются, если `can_transition` равен `false`. (файл `app/static/script.js`).
- Сохранена обратная совместимость маршрутов: добавлены новые поля ответа и уточнена логика прав без удаления существующего поведения для `admin`/`technologist`.

### Testing
- `python -m py_compile app/routes/desene_cpu.py` — успех. 
- `node --check app/static/script.js` — успех. 
- Локальный запуск приложения и автоматический снимок страницы `/desene_cpu` (Playwright) показали загрузку страницы и корректную отрисовку статистики; при старте среды зафиксировано предупреждение по фоновой Telegram-петельке, не связанное с внесёнными изменениями.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b271f373d0832dae18ed94bc1a418e)