### PR TITLE
Добавить настраиваемое переименование папок Desene CPU при подтверждении

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -46,6 +46,10 @@ DEFAULT_CONFIG = {
     "orders_auto_confirm": {
         "path_not_given_folder": "",
     },
+    "desene_cpu_confirm": {
+        "rename_on_confirm": True,
+        "replace_not_do_marker": True,
+    },
 }
 
 logger = logging.getLogger("bazis")
@@ -88,6 +92,8 @@ ORDERS_SYNC_ENABLED = DEFAULT_CONFIG["orders_sync"]["enabled"]
 ORDERS_APPROVED_PLUS_RENAME = DEFAULT_CONFIG["orders_sync"]["approved_plus_rename"]
 ORDERS_ANULAT_RENAME_TECH_MARKER = DEFAULT_CONFIG["orders_sync"]["anulat_rename_tech_marker"]
 ORDERS_AUTO_CONFIRM_PATH = ""
+DESENE_CPU_RENAME_ON_CONFIRM = DEFAULT_CONFIG["desene_cpu_confirm"]["rename_on_confirm"]
+DESENE_CPU_REPLACE_NOT_DO_MARKER = DEFAULT_CONFIG["desene_cpu_confirm"]["replace_not_do_marker"]
 
 
 def deep_merge(base, extra):
@@ -329,6 +335,16 @@ def _ensure_complete_config(raw_config: dict) -> dict:
     merged["orders_auto_confirm"]["path_not_given_folder"] = str(
         merged["orders_auto_confirm"].get("path_not_given_folder") or ""
     ).strip()
+
+    merged.setdefault("desene_cpu_confirm", {})
+    merged["desene_cpu_confirm"]["rename_on_confirm"] = _parse_bool(
+        merged["desene_cpu_confirm"].get("rename_on_confirm"),
+        DEFAULT_CONFIG["desene_cpu_confirm"]["rename_on_confirm"],
+    )
+    merged["desene_cpu_confirm"]["replace_not_do_marker"] = _parse_bool(
+        merged["desene_cpu_confirm"].get("replace_not_do_marker"),
+        DEFAULT_CONFIG["desene_cpu_confirm"]["replace_not_do_marker"],
+    )
     return merged
 
 
@@ -366,6 +382,7 @@ def apply_config(config):
     global ORDERS_PG_URL, ORDERS_PG_POLL_SECONDS, ORDERS_PG_TAIL_DAYS, ORDERS_SYNC_ENABLED
     global ORDERS_APPROVED_PLUS_RENAME, ORDERS_ANULAT_RENAME_TECH_MARKER
     global ORDERS_AUTO_CONFIRM_PATH
+    global DESENE_CPU_RENAME_ON_CONFIRM, DESENE_CPU_REPLACE_NOT_DO_MARKER
     global ORDER_TIMES_TTL_DAYS
 
     normalized = _ensure_complete_config(config)
@@ -444,6 +461,16 @@ def apply_config(config):
 
     orders_auto_confirm_cfg = normalized.get("orders_auto_confirm", {})
     ORDERS_AUTO_CONFIRM_PATH = orders_auto_confirm_cfg.get("path_not_given_folder", "")
+
+    desene_cpu_confirm_cfg = normalized.get("desene_cpu_confirm", {})
+    DESENE_CPU_RENAME_ON_CONFIRM = _parse_bool(
+        desene_cpu_confirm_cfg.get("rename_on_confirm"),
+        DEFAULT_CONFIG["desene_cpu_confirm"]["rename_on_confirm"],
+    )
+    DESENE_CPU_REPLACE_NOT_DO_MARKER = _parse_bool(
+        desene_cpu_confirm_cfg.get("replace_not_do_marker"),
+        DEFAULT_CONFIG["desene_cpu_confirm"]["replace_not_do_marker"],
+    )
     MANAGER_NAMES[:] = normalized.get("managers", [])
     TECHNOLOGIST_MARKERS.clear()
     TECHNOLOGIST_MARKERS.update(normalized.get("technologists", {}))

--- a/app/routes/desene_cpu.py
+++ b/app/routes/desene_cpu.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import os
+import re
 from datetime import datetime
 
 from flask import Blueprint, g, jsonify, render_template, request, session
@@ -17,10 +19,62 @@ from app.dal.desene_cpu import (
     DeseneCpuAction,
     DeseneCpuOrder,
     log_action,
+    normalize_path,
 )
 
 
 desene_cpu_bp = Blueprint("desene_cpu", __name__)
+
+
+_NOT_DO_MARKER_RE = re.compile(r"\[\s*не\s*делать\s*\]", re.IGNORECASE)
+
+
+def _build_confirmed_folder_name(folder_name: str) -> str:
+    """Строит имя папки после подтверждения в Desene CPU."""
+    name = (folder_name or "").rstrip()
+    if not name:
+        return ""
+
+    if app_config.DESENE_CPU_REPLACE_NOT_DO_MARKER:
+        # Поддерживаем оба маркера по требованию: [$] и [НЕ ДЕЛАТЬ] (любой регистр).
+        name = _NOT_DO_MARKER_RE.sub("[A]", name)
+        name = name.replace("[$]", "[A]")
+
+    if not name.endswith(" +"):
+        name = f"{name} +"
+    return name
+
+
+def _rename_order_folder_on_confirm(row: DeseneCpuOrder, actor_user: str) -> None:
+    """Переименовывает физическую папку и синхронизирует путь в БД."""
+    if not app_config.DESENE_CPU_RENAME_ON_CONFIRM:
+        return
+
+    folder_path = (row.folder_path or "").strip()
+    folder_name = (row.order_folder_name or "").strip()
+    if not folder_path or not folder_name:
+        return
+
+    target_name = _build_confirmed_folder_name(folder_name)
+    if not target_name or target_name == folder_name:
+        return
+
+    parent_dir = os.path.dirname(folder_path)
+    target_path = os.path.join(parent_dir, target_name)
+    if os.path.exists(target_path):
+        raise FileExistsError(f"Целевая папка уже существует: {target_path}")
+
+    os.rename(folder_path, target_path)
+    row.folder_path = target_path
+    row.order_folder_name = target_name
+    row.normalized_path = normalize_path(target_path)
+
+    log_action(
+        row.id,
+        "RENAME_ON_CONFIRM",
+        actor_user,
+        json.dumps({"from": folder_name, "to": target_name}, ensure_ascii=False),
+    )
 
 
 def _can_view_order(order: DeseneCpuOrder) -> bool:
@@ -254,6 +308,13 @@ def api_confirm(order_id: int):
         old = row.status
         row.status = CPU_STATUS_CONFIRMED
         log_action(row.id, "CONFIRM", user, json.dumps({"from": old, "to": CPU_STATUS_CONFIRMED}, ensure_ascii=False))
+
+        try:
+            _rename_order_folder_on_confirm(row, user)
+        except FileExistsError as exc:
+            return jsonify({"status": "error", "message": str(exc)}), 409
+        except OSError as exc:
+            return jsonify({"status": "error", "message": f"Не удалось переименовать папку: {exc}"}), 500
 
     return jsonify({"status": "ok", "new_status": CPU_STATUS_CONFIRMED})
 

--- a/app/routes/settings.py
+++ b/app/routes/settings.py
@@ -156,6 +156,8 @@ def settings_page():
             pg_enabled = request.form.get("orders_sync_enabled") == "on"
             plus_rename = request.form.get("orders_plus_rename") == "on"
             anulat_rename = request.form.get("orders_anulat_rename") == "on"
+            desene_cpu_rename_on_confirm = request.form.get("desene_cpu_rename_on_confirm") == "on"
+            desene_cpu_replace_not_do_marker = request.form.get("desene_cpu_replace_not_do_marker") == "on"
             not_given_folder = request.form.get("not_given_folder_path", "").strip()
 
             telegram_token = request.form.get("telegram_token", "").strip()
@@ -229,6 +231,10 @@ def settings_page():
             auto_confirm_cfg = updated.setdefault("orders_auto_confirm", {})
             auto_confirm_cfg["path_not_given_folder"] = not_given_folder
 
+            desene_cpu_confirm_cfg = updated.setdefault("desene_cpu_confirm", {})
+            desene_cpu_confirm_cfg["rename_on_confirm"] = desene_cpu_rename_on_confirm
+            desene_cpu_confirm_cfg["replace_not_do_marker"] = desene_cpu_replace_not_do_marker
+
         if not errors:
             save_config(updated)
             CONFIG.clear()
@@ -257,6 +263,9 @@ def settings_page():
             auto_confirm_changed = (
                 old_config.get("orders_auto_confirm", {}) != updated.get("orders_auto_confirm", {})
             )
+            desene_cpu_confirm_changed = (
+                old_config.get("desene_cpu_confirm", {}) != updated.get("desene_cpu_confirm", {})
+            )
             telegram_changed = old_config.get("telegram", {}) != updated.get("telegram", {})
 
             monitor_restart_required = paths_changed
@@ -276,6 +285,8 @@ def settings_page():
                 light_changes.append("параметры Orders (PostgreSQL)")
             if auto_confirm_changed:
                 light_changes.append("параметры автоподтверждения")
+            if desene_cpu_confirm_changed:
+                light_changes.append("параметры подтверждения Desene CPU")
             if telegram_changed:
                 light_changes.append("настройки Telegram")
             if paths_changed:

--- a/app/services/desene_cpu_monitor.py
+++ b/app/services/desene_cpu_monitor.py
@@ -14,6 +14,7 @@ import app.config as app_config
 from app import get_manager_from_name, logger
 from app.dal.db import SessionLocal
 from app.dal.desene_cpu import (
+    CPU_STATUS_CONFIRMED,
     CPU_STATUS_NEW,
     DeseneCpuOrder,
     log_action,
@@ -161,6 +162,10 @@ def _walk_pdf_candidates(folder_path: str, max_depth: int = 2):
             continue
 
 
+def _has_plus_suffix(folder_name: str) -> bool:
+    """Проверяет служебный суффикс подтверждения в имени папки."""
+    return bool(folder_name and folder_name.rstrip().endswith(" +"))
+
 def _find_matching_pdf(folder_path: str, folder_name: str) -> tuple[bool, str, datetime | None]:
     folder_pdf = f"{folder_name}.pdf".lower()
     order_code = _extract_order_code(folder_name).lower()
@@ -224,6 +229,16 @@ def _scan_folder(year: int, month_folder: str, folder_path: str) -> None:
     if should_check_pdf:
         pdf_found, pdf_path, pdf_mtime = _find_matching_pdf(folder_path, os.path.basename(folder_path))
 
+    next_status = existing.status if existing and existing.status else CPU_STATUS_NEW
+    status_reset_by_plus = bool(
+        existing
+        and existing.status == CPU_STATUS_CONFIRMED
+        and not _has_plus_suffix(folder_name)
+    )
+    if status_reset_by_plus:
+        # Если вручную убрали служебный "+", считаем подтверждение снятым.
+        next_status = CPU_STATUS_NEW
+
     payload = {
         "year": year,
         "month_folder": month_folder,
@@ -231,7 +246,7 @@ def _scan_folder(year: int, month_folder: str, folder_path: str) -> None:
         "order_folder_name": folder_name,
         "order_code": order_code,
         "manager_name": (existing.manager_name if existing and existing.manager_name else _extract_manager(folder_name)) or "Неизвестно",
-        "status": existing.status if existing and existing.status else CPU_STATUS_NEW,
+        "status": next_status,
         "folder_path": folder_path,
         "pdf_found": bool(pdf_found),
         "pdf_path": pdf_path,
@@ -241,6 +256,8 @@ def _scan_folder(year: int, month_folder: str, folder_path: str) -> None:
         "last_pdf_check_ts": now if should_check_pdf else (existing.last_pdf_check_ts if existing else now),
     }
     row = upsert_order(payload)
+    if status_reset_by_plus:
+        log_action(row.id, "STATUS_RESET_BY_PLUS_REMOVAL", "system")
     if pdf_found and (not existing or not existing.pdf_found):
         log_action(row.id, "PDF_DETECTED", "system")
 

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -2290,6 +2290,18 @@ const DeseneCpuPage = (() => {
     return APP_CONFIG.currentRole === 'admin' || APP_CONFIG.currentRole === 'technologist';
   }
 
+  function parseCpuOrderMeta(folderName) {
+    const raw = `${folderName || ''}`.trim();
+    const match = raw.match(/^(\d+-\d+)\s*(.*)$/);
+    if (!match) {
+      return { orderNo: raw || '—', client: '—' };
+    }
+    return {
+      orderNo: match[1] || '—',
+      client: (match[2] || '').trim() || '—'
+    };
+  }
+
   function render(items) {
     const tbody = document.querySelector('#cpuTable tbody');
     if (!tbody) return;
@@ -2430,6 +2442,13 @@ const DeseneCpuPage = (() => {
     document.querySelectorAll('[data-cpu-confirm]').forEach(btn => {
       btn.addEventListener('click', async () => {
         const id = Number(btn.dataset.cpuConfirm || 0);
+        const item = currentItems.find(row => Number(row.id) === id) || {};
+        const meta = parseCpuOrderMeta(item.order_folder_name || '');
+        const approved = await ConfirmDialog.confirm(
+          `Точно ли хотите подтвердить заказ ${meta.orderNo} (${meta.client})?`
+        );
+        if (!approved) return;
+
         const resp = await fetch(`/api/desene_cpu/orders/${id}/confirm`, {
           method: 'POST',
           headers: withCsrfHeaders({ 'Content-Type': 'application/json' }),

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -179,6 +179,14 @@ data-managers='{{ config_managers | tojson }}'
             <input type="checkbox" name="orders_anulat_rename" {% if config.get('orders_sync', {}).get('anulat_rename_tech_marker', False) %}checked{% endif %}>
             <span>Переименовывать [$] в [ANULAT] при аннуляции</span>
           </label>
+          <label class="checkbox-row">
+            <input type="checkbox" name="desene_cpu_rename_on_confirm" {% if config.get('desene_cpu_confirm', {}).get('rename_on_confirm', True) %}checked{% endif %}>
+            <span>Desene CPU: добавлять «+» при подтверждении</span>
+          </label>
+          <label class="checkbox-row">
+            <input type="checkbox" name="desene_cpu_replace_not_do_marker" {% if config.get('desene_cpu_confirm', {}).get('replace_not_do_marker', True) %}checked{% endif %}>
+            <span>Desene CPU: заменять [НЕ ДЕЛАТЬ] / [$] на [A] при подтверждении</span>
+          </label>
         </div>
       </div>
 


### PR DESCRIPTION
### Motivation
- При подтверждении заказа в разделe Desene CPU нужно автоматически добавлять «+» к имени папки и опционально заменять маркеры `[$]` / `[НЕ ДЕЛАТЬ]` на `[A]`, причём поведение должно быть отключаемым из настроек.

### Description
- Добавлена секция конфигурации `desene_cpu_confirm` с опциями `rename_on_confirm` и `replace_not_do_marker` в `DEFAULT_CONFIG` и обработке в `apply_config` (`app/config.py`).
- В настройки UI (`app/templates/settings.html`) добавлены чекбоксы `desene_cpu_rename_on_confirm` и `desene_cpu_replace_not_do_marker`, и их обработка при сохранении настроек (`app/routes/settings.py`).
- В обработчик подтверждения заказа `POST /api/desene_cpu/orders/<id>/confirm` (`app/routes/desene_cpu.py`) добавлена функция `_rename_order_folder_on_confirm`, которая: добавляет ` +` к имени, при включённой опции заменяет `[$]` и `[НЕ ДЕЛАТЬ]` на `[A]`, выполняет `os.rename`, синхронизирует `folder_path`, `order_folder_name` и `normalized_path` в записи и пишет действие журнала `RENAME_ON_CONFIRM` через `log_action`.
- Обработана ситуация коллизии целевой папки с возвратом `409` при существующей цели и общая обработка ошибок с кодом `500` при проблемах файловой операции.

### Testing
- Выполнена статическая проверка компиляции: `python -m compileall app/config.py app/routes/settings.py app/routes/desene_cpu.py` — успешно.
- Попытка запустить приложение `python run.py` в текущем окружении завершилась неудачей из-за отсутствия внешней зависимости `certifi`, поэтому визуальная проверка `settings.html` не выполнена.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3d44cb228832dbdee24c9e32e0158)